### PR TITLE
Make the remote script compatible to python 2 for Ableton Live 10 

### DIFF
--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -186,6 +186,10 @@ class AbletonMCP(ControlSurface):
                         "message": str(e)
                     }
                     try:
+                        # Python 3: encode string to bytes
+                        client.sendall(json.dumps(error_response).encode('utf-8'))
+                    except AttributeError:
+                        # Python 2: string is already bytes
                         client.sendall(json.dumps(error_response))
                     except:
                         # If we can't send the error, the connection is probably dead

--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -7,7 +7,12 @@ import json
 import threading
 import time
 import traceback
-import queue
+
+# Change queue import for Python 2
+try:
+    import Queue as queue  # Python 2
+except ImportError:
+    import queue  # Python 3
 
 # Constants for socket communication
 DEFAULT_PORT = 9877
@@ -62,7 +67,7 @@ class AbletonMCP(ControlSurface):
         for client_thread in self.client_threads[:]:
             if client_thread.is_alive():
                 # We don't join them as they might be stuck
-                self.log_message(f"Client thread still alive during disconnect")
+                self.log_message("Client thread still alive during disconnect")
         
         ControlSurface.disconnect(self)
         self.log_message("AbletonMCP disconnected")
@@ -129,7 +134,7 @@ class AbletonMCP(ControlSurface):
         """Handle communication with a connected client"""
         self.log_message("Client handler started")
         client.settimeout(None)  # No timeout for client socket
-        buffer = b''
+        buffer = ''  # Changed from b'' to '' for Python 2
         
         try:
             while self.running:
@@ -142,21 +147,31 @@ class AbletonMCP(ControlSurface):
                         self.log_message("Client disconnected")
                         break
                     
-                    # Accumulate data in buffer
-                    buffer += data
+                    # Accumulate data in buffer with explicit encoding/decoding
+                    try:
+                        # Python 3: data is bytes, decode to string
+                        buffer += data.decode('utf-8')
+                    except AttributeError:
+                        # Python 2: data is already string
+                        buffer += data
                     
                     try:
                         # Try to parse command from buffer
-                        command = json.loads(buffer.decode('utf-8'))
-                        buffer = b''  # Clear buffer after successful parse
+                        command = json.loads(buffer)  # Removed decode('utf-8')
+                        buffer = ''  # Clear buffer after successful parse
                         
                         self.log_message("Received command: " + str(command.get("type", "unknown")))
                         
                         # Process the command and get response
                         response = self._process_command(command)
                         
-                        # Send the response
-                        client.sendall(json.dumps(response).encode('utf-8'))
+                        # Send the response with explicit encoding
+                        try:
+                            # Python 3: encode string to bytes
+                            client.sendall(json.dumps(response).encode('utf-8'))
+                        except AttributeError:
+                            # Python 2: string is already bytes
+                            client.sendall(json.dumps(response))
                     except json.JSONDecodeError:
                         # Incomplete data, wait for more
                         continue
@@ -171,7 +186,7 @@ class AbletonMCP(ControlSurface):
                         "message": str(e)
                     }
                     try:
-                        client.sendall(json.dumps(error_response).encode('utf-8'))
+                        client.sendall(json.dumps(error_response))
                     except:
                         # If we can't send the error, the connection is probably dead
                         break
@@ -272,7 +287,11 @@ class AbletonMCP(ControlSurface):
                         response_queue.put({"status": "error", "message": str(e)})
                 
                 # Schedule the task to run on the main thread
-                self.schedule_message(0, main_thread_task)
+                try:
+                    self.schedule_message(0, main_thread_task)
+                except AssertionError:
+                    # If we're already on the main thread, execute directly
+                    main_thread_task()
                 
                 # Wait for the response with a timeout
                 try:
@@ -679,7 +698,7 @@ class AbletonMCP(ControlSurface):
                             break
                     
                     if not found:
-                        result["error"] = f"Path part '{part}' not found"
+                        result["error"] = "Path part '{0}' not found".format(part)
                         return result
                 
                 # Found the item
@@ -715,7 +734,7 @@ class AbletonMCP(ControlSurface):
             item = self._find_browser_item_by_uri(app.browser, item_uri)
             
             if not item:
-                raise ValueError(f"Browser item with URI '{item_uri}' not found")
+                raise ValueError("Browser item with URI '{0}' not found".format(item_uri))
             
             # Select the track
             self._song.view.selected_track = track
@@ -731,7 +750,7 @@ class AbletonMCP(ControlSurface):
             }
             return result
         except Exception as e:
-            self.log_message(f"Error loading browser item: {str(e)}")
+            self.log_message("Error loading browser item: {0}".format(str(e)))
             self.log_message(traceback.format_exc())
             raise
     
@@ -773,7 +792,7 @@ class AbletonMCP(ControlSurface):
             
             return None
         except Exception as e:
-            self.log_message(f"Error finding browser item by URI: {str(e)}")
+            self.log_message("Error finding browser item by URI: {0}".format(str(e)))
             return None
     
     # Helper methods
@@ -819,7 +838,7 @@ class AbletonMCP(ControlSurface):
             
             # Log available browser attributes to help diagnose issues
             browser_attrs = [attr for attr in dir(app.browser) if not attr.startswith('_')]
-            self.log_message(f"Available browser attributes: {browser_attrs}")
+            self.log_message("Available browser attributes: {0}".format(browser_attrs))
             
             result = {
                 "type": category_type,
@@ -852,7 +871,7 @@ class AbletonMCP(ControlSurface):
                         instruments["name"] = "Instruments"  # Ensure consistent naming
                         result["categories"].append(instruments)
                 except Exception as e:
-                    self.log_message(f"Error processing instruments: {str(e)}")
+                    self.log_message("Error processing instruments: {0}".format(str(e)))
             
             if (category_type == "all" or category_type == "sounds") and hasattr(app.browser, 'sounds'):
                 try:
@@ -861,7 +880,7 @@ class AbletonMCP(ControlSurface):
                         sounds["name"] = "Sounds"  # Ensure consistent naming
                         result["categories"].append(sounds)
                 except Exception as e:
-                    self.log_message(f"Error processing sounds: {str(e)}")
+                    self.log_message("Error processing sounds: {0}".format(str(e)))
             
             if (category_type == "all" or category_type == "drums") and hasattr(app.browser, 'drums'):
                 try:
@@ -870,7 +889,7 @@ class AbletonMCP(ControlSurface):
                         drums["name"] = "Drums"  # Ensure consistent naming
                         result["categories"].append(drums)
                 except Exception as e:
-                    self.log_message(f"Error processing drums: {str(e)}")
+                    self.log_message("Error processing drums: {0}".format(str(e)))
             
             if (category_type == "all" or category_type == "audio_effects") and hasattr(app.browser, 'audio_effects'):
                 try:
@@ -879,16 +898,16 @@ class AbletonMCP(ControlSurface):
                         audio_effects["name"] = "Audio Effects"  # Ensure consistent naming
                         result["categories"].append(audio_effects)
                 except Exception as e:
-                    self.log_message(f"Error processing audio_effects: {str(e)}")
+                    self.log_message("Error processing audio_effects: {0}".format(str(e)))
             
             if (category_type == "all" or category_type == "midi_effects") and hasattr(app.browser, 'midi_effects'):
                 try:
                     midi_effects = process_item(app.browser.midi_effects)
                     if midi_effects:
-                        midi_effects["name"] = "MIDI Effects"  # Ensure consistent naming
+                        midi_effects["name"] = "MIDI Effects"
                         result["categories"].append(midi_effects)
                 except Exception as e:
-                    self.log_message(f"Error processing midi_effects: {str(e)}")
+                    self.log_message("Error processing midi_effects: {0}".format(str(e)))
             
             # Try to process other potentially available categories
             for attr in browser_attrs:
@@ -899,16 +918,17 @@ class AbletonMCP(ControlSurface):
                         if hasattr(item, 'children') or hasattr(item, 'name'):
                             category = process_item(item)
                             if category:
-                                category["name"] = attr.capitalize()  # Use attribute name as category name
+                                category["name"] = attr.capitalize()
                                 result["categories"].append(category)
                     except Exception as e:
-                        self.log_message(f"Error processing {attr}: {str(e)}")
+                        self.log_message("Error processing {0}: {1}".format(attr, str(e)))
             
-            self.log_message(f"Browser tree generated for {category_type} with {len(result['categories'])} root categories")
+            self.log_message("Browser tree generated for {0} with {1} root categories".format(
+                category_type, len(result['categories'])))
             return result
             
         except Exception as e:
-            self.log_message(f"Error getting browser tree: {str(e)}")
+            self.log_message("Error getting browser tree: {0}".format(str(e)))
             self.log_message(traceback.format_exc())
             raise
     
@@ -936,7 +956,7 @@ class AbletonMCP(ControlSurface):
             
             # Log available browser attributes to help diagnose issues
             browser_attrs = [attr for attr in dir(app.browser) if not attr.startswith('_')]
-            self.log_message(f"Available browser attributes: {browser_attrs}")
+            self.log_message("Available browser attributes: {0}".format(browser_attrs))
                 
             # Parse the path
             path_parts = path.split("/")
@@ -968,13 +988,13 @@ class AbletonMCP(ControlSurface):
                             found = True
                             break
                         except Exception as e:
-                            self.log_message(f"Error accessing browser attribute {attr}: {str(e)}")
+                            self.log_message("Error accessing browser attribute {0}: {1}".format(attr, str(e)))
                 
                 if not found:
                     # If we still haven't found the category, return available categories
                     return {
                         "path": path,
-                        "error": f"Unknown or unavailable category: {root_category}",
+                        "error": "Unknown or unavailable category: {0}".format(root_category),
                         "available_categories": browser_attrs,
                         "items": []
                     }
@@ -988,7 +1008,7 @@ class AbletonMCP(ControlSurface):
                 if not hasattr(current_item, 'children'):
                     return {
                         "path": path,
-                        "error": f"Item at '{'/'.join(path_parts[:i])}' has no children",
+                        "error": "Item at '{0}' has no children".format('/'.join(path_parts[:i])),
                         "items": []
                     }
                 
@@ -1002,7 +1022,7 @@ class AbletonMCP(ControlSurface):
                 if not found:
                     return {
                         "path": path,
-                        "error": f"Path part '{part}' not found",
+                        "error": "Path part '{0}' not found".format(part),
                         "items": []
                     }
             
@@ -1029,10 +1049,10 @@ class AbletonMCP(ControlSurface):
                 "items": items
             }
             
-            self.log_message(f"Retrieved {len(items)} items at path: {path}")
+            self.log_message("Retrieved {0} items at path: {1}".format(len(items), path))
             return result
             
         except Exception as e:
-            self.log_message(f"Error getting browser items at path: {str(e)}")
+            self.log_message("Error getting browser items at path: {0}".format(str(e)))
             self.log_message(traceback.format_exc())
             raise

--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -172,7 +172,7 @@ class AbletonMCP(ControlSurface):
                         except AttributeError:
                             # Python 2: string is already bytes
                             client.sendall(json.dumps(response))
-                    except json.JSONDecodeError:
+                    except ValueError:
                         # Incomplete data, wait for more
                         continue
                         
@@ -192,7 +192,7 @@ class AbletonMCP(ControlSurface):
                         break
                     
                     # For serious errors, break the loop
-                    if not isinstance(e, json.JSONDecodeError):
+                    if not isinstance(e, ValueError):
                         break
         except Exception as e:
             self.log_message("Error in client handler: " + str(e))


### PR DESCRIPTION
In order to support Ableton Live 10, the remote script should be able to run in python 2 as well, as per the statement:

"Live 10 and earlier versions used Python 2 for remote scripts. This has been upgraded to Python 3, as of Live 11. All third-party and custom scripts must use Python 3 to work in Live 11 and later versions."
https://help.ableton.com/hc/en-us/articles/209072009-Installing-third-party-remote-scripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved system stability and performance through enhanced compatibility across diverse runtime environments. These behind‑the‑scenes updates refine data handling, error processing, and logging to ensure the software operates more reliably and efficiently. While there are no changes to visible functionality, users can expect a smoother, more robust experience. These maintenance improvements ensure smoother operation and ongoing quality across all supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->