### PR TITLE
1. Add the ability to record a Session Clip into Arrangement View and 2. Switch between Session and Arrangement Views

### DIFF
--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -229,7 +229,8 @@ class AbletonMCP(ControlSurface):
             elif command_type in ["create_midi_track", "set_track_name", 
                                  "create_clip", "add_notes_to_clip", "set_clip_name", 
                                  "set_tempo", "fire_clip", "stop_clip",
-                                 "start_playback", "stop_playback", "load_browser_item"]:
+                                 "start_playback", "stop_playback", "load_browser_item", 
+                                 "record_arrangement_clip", "switch_to_view"]:
                 # Use a thread-safe approach with a response queue
                 response_queue = queue.Queue()
                 
@@ -282,6 +283,16 @@ class AbletonMCP(ControlSurface):
                             track_index = params.get("track_index", 0)
                             item_uri = params.get("item_uri", "")
                             result = self._load_browser_item(track_index, item_uri)
+                        elif command_type == "record_arrangement_clip": # Handle new command
+                            track_index = params.get("track_index", 0)
+                            start_time = params.get("start_time", 0.0)
+                            length = params.get("length", 4.0)
+                            clip_index = params.get("clip_index", 0)
+                            clip_name = params.get("clip_name", "")
+                            result = self._record_clip_to_arrangement(track_index, start_time, length, clip_index, clip_name)
+                        elif command_type == "switch_to_view":
+                            view_name = params.get("view_name", "Arranger")
+                            result = self._switch_to_view(view_name)
                         
                         # Put the result in the queue
                         response_queue.put({"status": "success", "result": result})
@@ -480,7 +491,66 @@ class AbletonMCP(ControlSurface):
         except Exception as e:
             self.log_message("Error creating clip: " + str(e))
             raise
+        
+    def _get_clip_slot_by_name(self, track, clip_name):
+        for clip_slot in track.clip_slots:
+            if clip_slot.has_clip and clip_slot.clip.name == clip_name:
+                return clip_slot
+        return None
     
+    def _record_clip_to_arrangement(self, track_index, start_time, length, clip_index, clip_name):
+        """Record a new Arrangement MIDI clip in the Arrangement View at the specified time."""
+        try:
+            track = self.song().tracks[track_index]
+            if track.can_be_armed and not track.arm:
+                track.arm = True
+                
+            clip_slot = None
+            
+            if clip_name:
+                clip_slot = self._get_clip_slot_by_name(track, clip_name)
+            else:
+                clip_slot = track.clip_slots[clip_index]
+            
+            clip_slot.fire()
+            # Start Recording the Session Clip into Arrangement View
+            self._song.record_mode = True
+            self._song.start_playing()
+            self._song.is_playing = True
+            self._song.start_time = start_time
+
+            time.sleep(length * 60.0 / self._song.tempo)
+
+            self._song.is_playing = False
+            self._song.stop_playing()
+            self._song.record_mode = False
+            clip_slot.stop()
+
+            result = {
+                "created_arrangement_clip": True
+            }
+            return result
+        except Exception as e:
+            self.log_message("Error creating arrangement clip: " + str(e))
+            raise
+        
+    def _switch_to_view(self, view_name):
+        """Switch between 'Session' and 'Arranger' views"""
+        try:
+            view = self.application().view
+            
+            if view_name == "Session":
+                view.focus_view("Session")
+                self._song.back_to_arranger = False
+            else:
+                view.focus_view("Arranger")
+                self._song.back_to_arranger = True
+            
+            return {"view": view_name}
+        except Exception as e:
+            self.log_message("Error switching views: " + str(e))
+            raise
+
     def _add_notes_to_clip(self, track_index, clip_index, notes):
         """Add MIDI notes to a clip"""
         try:

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -105,7 +105,8 @@ class AbletonConnection:
             "create_midi_track", "create_audio_track", "set_track_name",
             "create_clip", "add_notes_to_clip", "set_clip_name",
             "set_tempo", "fire_clip", "stop_clip", "set_device_parameter",
-            "start_playback", "stop_playback", "load_instrument_or_effect"
+            "start_playback", "stop_playback", "load_instrument_or_effect",
+            "record_arrangement_clip", "switch_to_view"
         ]
         
         try:
@@ -336,6 +337,8 @@ def create_clip(ctx: Context, track_index: int, clip_index: int, length: float =
             "clip_index": clip_index, 
             "length": length
         })
+        ableton.send_command("switch_to_view", {"view_name": "Session"})
+
         return f"Created new clip at track {track_index}, slot {clip_index} with length {length} beats"
     except Exception as e:
         logger.error(f"Error creating clip: {str(e)}")
@@ -651,6 +654,69 @@ def load_drum_kit(ctx: Context, track_index: int, rack_uri: str, kit_path: str) 
     except Exception as e:
         logger.error(f"Error loading drum kit: {str(e)}")
         return f"Error loading drum kit: {str(e)}"
+
+@mcp.tool()
+def switch_to_view(ctx: Context, view_name: str = "Arranger") -> str:
+    """
+    Switch between Arrangement (called Arranger) and Session View
+    
+    Parameters:
+    - view_name: Either "Arranger" or "Session"
+    """
+    try:
+
+        ableton = get_ableton_connection()
+        
+        # Validate view name
+        view_name = view_name.capitalize()
+        if view_name not in ["Arranger", "Session"]:
+            return f"Invalid view name. Must be either 'Arrangement' or 'Session'"
+            
+        result = ableton.send_command("switch_to_view", {
+            "view_name": view_name
+        })
+        
+        return f"Switched to {view_name} view. Result: {result}"
+    except Exception as e:
+        logger.error(f"Error switching view: {str(e)}")
+        return f"Error switching view: {str(e)}"
+
+@mcp.tool()
+def record_arrangement_clip(
+    ctx: Context,
+    track_index: int,
+    start_time: float = 0.0,
+    length: float = 4.0,
+    clip_index: int = -1,
+    clip_name: str = ""
+) -> str:
+    """
+    Record into the Arrangement View from the Session View
+    
+    Parameters:
+    - track_index: Which track to create the clip on
+    - start_time: Start time in beats
+    - length: Length of the clip in beats
+    """
+    try:
+        ableton = get_ableton_connection()
+        
+        # Create the clip in arrangement view
+        result = ableton.send_command("record_arrangement_clip", {
+            "track_index": track_index,
+            "start_time": start_time,
+            "length": length,
+            "clip_index": clip_index,
+            "clip_name": clip_name
+        })
+        
+        # Switch to Arrangement View
+        ableton.send_command("switch_to_view", {"view_name": "Arranger"})
+        
+        return f"Created arrangement clip from Track ${track_index}"
+    except Exception as e:
+        logger.error(f"Error creating arrangement clip: {str(e)}")
+        return f"Error creating arrangement clip: {str(e)}"
 
 # Main execution
 def main():


### PR DESCRIPTION
### **User description**
Primary Motivations: I mainly work in Arrangement View when I make a song so I wanted to add two convenience methods to the MCP. I also think that if you're creating a Session Clip its easier for the user to see what's happening if you switch to the Session View since most people start in Arrangement View by default.


Switch between Session and Arrangement View Demonstration:

![switch_to_view](https://github.com/user-attachments/assets/1adb480d-4fe1-4730-bab8-25cd72c59a2c)
video link: https://drive.google.com/file/d/1Qr8NponBHczc7exToRxN30X9mc8_4KrM/view?usp=drive_link


Record a Session Clip into Arrangement View Demonstration:

![record_into_arrangement](https://github.com/user-attachments/assets/cea9dcf5-ad49-4216-9f58-6cdf036602b8)

video link: https://drive.google.com/file/d/1qIOPs7p4QXiCVZpaZ6RegrE3avzKqAdC/view?usp=drive_link

This way you can 
1. Use Claude to Create a Session Clip with MIDI
2. Record it straight into the Arrangement View

This allows Claude to potentially chain the two actions together (create a musical idea in Session View and then automatically recording it into Arrangement Mode)


___

### **PR Type**
Enhancement


___

### **Description**
- Added functionality to switch between Session and Arrangement views.

- Implemented recording of Session Clips into Arrangement View.

- Enhanced command handling with new commands: `record_arrangement_clip` and `switch_to_view`.

- Updated server-side tools to support new view-switching and recording features.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Introduced commands for view switching and clip recording</code></dd></summary>
<hr>

AbletonMCP_Remote_Script/__init__.py

<li>Added <code>record_arrangement_clip</code> and <code>switch_to_view</code> commands.<br> <li> Implemented <code>_record_clip_to_arrangement</code> for recording clips into <br>Arrangement View.<br> <li> Added <code>_switch_to_view</code> for toggling between Session and Arrangement <br>views.<br> <li> Enhanced error handling for new functionalities.


</details>


  </td>
  <td><a href="https://github.com/ahujasid/ableton-mcp/pull/17/files#diff-b37b5e56eb238d75c4d6e209294bd29a2bb340d30784896b21be1c0b0a875227">+72/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>server.py</strong><dd><code>Added tools for view switching and clip recording</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

MCP_Server/server.py

<li>Added <code>switch_to_view</code> tool for toggling views.<br> <li> Added <code>record_arrangement_clip</code> tool for recording Session Clips.<br> <li> Updated <code>create_clip</code> to switch to Session View after creation.<br> <li> Enhanced logging and error handling for new tools.


</details>


  </td>
  <td><a href="https://github.com/ahujasid/ableton-mcp/pull/17/files#diff-005f3183c50f439978d9b89e15b6c900dabed75ff0ecec955168d7a126036fc9">+67/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a command that lets you record clips directly in the arrangement view for streamlined clip management.
  - Added a command to switch seamlessly between Session and Arranger views, enhancing navigation and workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->