### PR TITLE
feat: Add get_notes_from_clip to read MIDI notes from clips

### DIFF
--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -186,7 +186,7 @@ async def server_lifespan(server: FastMCP) -> AsyncIterator[Dict[str, Any]]:
 # Create the MCP server with lifespan support
 mcp = FastMCP(
     "AbletonMCP",
-    description="Ableton Live integration through the Model Context Protocol",
+    instructions="Ableton Live integration through the Model Context Protocol",
     lifespan=server_lifespan
 )
 

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -343,14 +343,14 @@ def create_clip(ctx: Context, track_index: int, clip_index: int, length: float =
 
 @mcp.tool()
 def add_notes_to_clip(
-    ctx: Context, 
-    track_index: int, 
-    clip_index: int, 
+    ctx: Context,
+    track_index: int,
+    clip_index: int,
     notes: List[Dict[str, Union[int, float, bool]]]
 ) -> str:
     """
     Add MIDI notes to a clip.
-    
+
     Parameters:
     - track_index: The index of the track containing the clip
     - clip_index: The index of the clip slot containing the clip
@@ -367,6 +367,29 @@ def add_notes_to_clip(
     except Exception as e:
         logger.error(f"Error adding notes to clip: {str(e)}")
         return f"Error adding notes to clip: {str(e)}"
+
+@mcp.tool()
+def get_notes_from_clip(ctx: Context, track_index: int, clip_index: int) -> str:
+    """
+    Get all MIDI notes from a clip.
+
+    Parameters:
+    - track_index: The index of the track containing the clip
+    - clip_index: The index of the clip slot containing the clip
+
+    Returns: JSON with clip_name, length, note_count, and notes array.
+             Each note has pitch, start_time, duration, velocity, and mute.
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("get_notes_from_clip", {
+            "track_index": track_index,
+            "clip_index": clip_index
+        })
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        logger.error(f"Error getting notes from clip: {str(e)}")
+        return f"Error getting notes from clip: {str(e)}"
 
 @mcp.tool()
 def set_clip_name(ctx: Context, track_index: int, clip_index: int, name: str) -> str:

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Once the config file has been set on Claude, and the remote script is running in
 - Control playback
 - Load instruments and effects from Ableton's browser
 - Add notes to MIDI clips
+- **Read notes from existing MIDI clips** (NEW)
 - Change tempo and other session parameters
 
 ## Example Commands
@@ -143,6 +144,8 @@ Here are some examples of what you can ask Claude to do:
 - "Get information about the current Ableton session"
 - "Load a 808 drum rack into the selected track"
 - "Add a jazz chord progression to the clip in track 1"
+- "Show me the notes in the drum clip on track 3"
+- "Get the MIDI notes from the first clip and transpose them up an octave"
 - "Set the tempo to 120 BPM"
 - "Play the clip in track 2"
 

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "ableton-mcp"
-version = "0.1.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
### **User description**
## Summary

This PR adds a new `get_notes_from_clip` function that allows reading existing MIDI notes from clips in Ableton Live. This was previously missing from the API - we could write notes but not read them.

**New capability:**
- `get_notes_from_clip(track_index, clip_index)` returns JSON with:
  - `clip_name`: Name of the clip
  - `length`: Clip length in beats  
  - `note_count`: Number of notes
  - `notes`: Array of note objects (pitch, start_time, duration, velocity, mute)

## Use Cases

- Analyze existing clips and patterns
- Visualize MIDI data
- Transpose or transform notes programmatically
- Build on existing musical content
- AI-assisted music production workflows

## Changes

- `AbletonMCP_Remote_Script/__init__.py`: Added `_get_notes_from_clip()` method using `clip.get_notes_extended()` API
- `MCP_Server/server.py`: Added `@mcp.tool()` decorated `get_notes_from_clip()` function
- `MCP_Server/server.py`: Updated FastMCP init to use `instructions` parameter (newer mcp library compatibility)
- `README.md`: Updated capabilities list and example commands

## Test Plan

- [x] Tested reading drum clips with 100+ notes
- [x] Tested with different clip lengths (4, 8, 32 beats)
- [x] Verified all note properties are returned correctly
- [x] Works with both Live 11 and Live 12

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>


___

### **PR Type**
Enhancement


___

### **Description**
- Add `get_notes_from_clip()` function to read MIDI notes from clips

- Implement note retrieval using Ableton's `get_notes_extended()` API

- Update FastMCP initialization parameter from `description` to `instructions`

- Expand README with new capability and usage examples


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User Request"] -->|track_index, clip_index| B["get_notes_from_clip"]
  B -->|sends command| C["Remote Script Handler"]
  C -->|_get_notes_from_clip| D["Ableton API"]
  D -->|get_notes_extended| E["Extract Note Data"]
  E -->|format notes| F["JSON Response"]
  F -->|clip_name, length, notes| A
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Implement note reading from MIDI clips</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AbletonMCP_Remote_Script/__init__.py

<ul><li>Added command routing for <code>get_notes_from_clip</code> in <code>_process_command()</code><br> <li> Implemented <code>_get_notes_from_clip()</code> method using Ableton's <br><code>get_notes_extended()</code> API<br> <li> Extracts pitch, start_time, duration, velocity, and mute properties <br>from notes<br> <li> Returns clip metadata (name, length, note_count) along with notes <br>array<br> <li> Fixed whitespace formatting in <code>_add_notes_to_clip()</code> method</ul>


</details>


  </td>
  <td><a href="https://github.com/ahujasid/ableton-mcp/pull/54/files#diff-b37b5e56eb238d75c4d6e209294bd29a2bb340d30784896b21be1c0b0a875227">+58/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>server.py</strong><dd><code>Add MCP tool for reading clip notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

MCP_Server/server.py

<ul><li>Added <code>@mcp.tool()</code> decorated <code>get_notes_from_clip()</code> function<br> <li> Updated FastMCP initialization to use <code>instructions</code> parameter instead <br>of deprecated <code>description</code><br> <li> Function sends command to remote script and returns JSON-formatted <br>note data<br> <li> Fixed whitespace formatting in <code>add_notes_to_clip()</code> docstring</ul>


</details>


  </td>
  <td><a href="https://github.com/ahujasid/ableton-mcp/pull/54/files#diff-005f3183c50f439978d9b89e15b6c900dabed75ff0ecec955168d7a126036fc9">+28/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document new note reading capability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Added "Read notes from existing MIDI clips" to capabilities list with <br>NEW marker<br> <li> Added two example commands demonstrating note reading and <br>transposition workflows</ul>


</details>


  </td>
  <td><a href="https://github.com/ahujasid/ableton-mcp/pull/54/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Retrieve MIDI notes from existing clips with detailed note information including pitch, timing, duration, velocity, and mute status. Metadata includes clip name and total note count.

* **Documentation**
  * Updated with new command examples and capability descriptions for reading MIDI note data from clips.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->