### PR TITLE
Update server.py commented out unsupported field

### DIFF
--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -186,7 +186,7 @@ async def server_lifespan(server: FastMCP) -> AsyncIterator[Dict[str, Any]]:
 # Create the MCP server with lifespan support
 mcp = FastMCP(
     "AbletonMCP",
-    description="Ableton Live integration through the Model Context Protocol",
+    # FIELD NO LONGER SUPPORTED description="Ableton Live integration through the Model Context Protocol", 
     lifespan=server_lifespan
 )
 


### PR DESCRIPTION
### **User description**
Description field no longer supported, causing image to not build.

Commented it out to get script working


___

### **PR Type**
Bug fix


___

### **Description**
- Comment out unsupported `description` parameter in FastMCP initialization

- Add newline at end of file for proper formatting


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FastMCP initialization"] -->|Remove unsupported field| B["Comment out description parameter"]
  B -->|Fix formatting| C["Add newline at EOF"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.py</strong><dd><code>Comment unsupported description field and fix EOF</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

MCP_Server/server.py

<ul><li>Comment out the <code>description</code> parameter in <code>FastMCP()</code> constructor call as <br>it is no longer supported<br> <li> Add newline character at end of file for proper file formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/ahujasid/ableton-mcp/pull/56/files#diff-005f3183c50f439978d9b89e15b6c900dabed75ff0ecec955168d7a126036fc9">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

