### PR TITLE
Feature Request: Add ability to read MIDI notes from existing clips 

### DIFF
--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -339,6 +339,35 @@ def create_clip(ctx: Context, track_index: int, clip_index: int, length: float =
     except Exception as e:
         logger.error(f"Error creating clip: {str(e)}")
         return f"Error creating clip: {str(e)}"
+    
+@mcp.tool()
+def get_clip_notes(ctx: Context, track_index: int, clip_index: int) -> str:
+    """
+    Get MIDI note data from an existing clip.
+    
+    Parameters:
+    - track_index: The index of the track containing the clip
+    - clip_index: The index of the clip slot containing the clip
+    
+    Returns:
+    - Dictionary containing note data with properties:
+      - notes: List of note objects with pitch, start_time, duration, velocity, mute
+      - clip_length: Length of the clip in beats
+      - quantization: Current quantization settings
+      - scale_info: Detected scale/key information (if possible)
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("get_clip_notes", {
+            "track_index": track_index,
+            "clip_index": clip_index
+        })
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        logger.error(f"Error getting clip notes: {str(e)}")
+        return f"Error getting clip notes: {str(e)}"
+
+
 
 @mcp.tool()
 def add_notes_to_clip(
@@ -366,6 +395,9 @@ def add_notes_to_clip(
     except Exception as e:
         logger.error(f"Error adding notes to clip: {str(e)}")
         return f"Error adding notes to clip: {str(e)}"
+    
+
+            
 
 @mcp.tool()
 def set_clip_name(ctx: Context, track_index: int, clip_index: int, name: str) -> str:


### PR DESCRIPTION
(get_clip_notes) Issue 35 I believe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced MIDI clip note retrieval feature providing comprehensive access to detailed note data and metadata from Ableton clips, including individual note information, precise clip length measurements, quantization settings, and associated scale details. This enables enhanced clip analysis, improved integration capabilities, and support for advanced automation workflow possibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->