### PR TITLE
fix: correct typo 'nstruments' to 'instruments'

### DIFF
--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -672,7 +672,7 @@ class AbletonMCP(ControlSurface):
                 
                 # Determine the root based on the first part
                 current_item = None
-                if path_parts[0].lower() == "nstruments":
+                if path_parts[0].lower() == "instruments":
                     current_item = app.browser.instruments
                 elif path_parts[0].lower() == "sounds":
                     current_item = app.browser.sounds


### PR DESCRIPTION
## Summary
Fixes a typo in the browser path parsing logic where `"nstruments"` was incorrectly spelled instead of `"instruments"`.

## Changes
- Line 675 in `AbletonMCP_Remote_Script/__init__.py`: `"nstruments"` → `"instruments"`

## Testing
- ✅ Python syntax check passed (`py_compile`)
- No existing tests in the project for this module

## Impact
This fix ensures that the `instruments` browser category is correctly recognized when navigating through Ableton's browser.

Closes #74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed browser navigation path handling to ensure correct root category selection and proper item traversal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->