### PR TITLE
Fix typo: 'nstruments' → 'instruments'

### DIFF
--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -672,7 +672,7 @@ class AbletonMCP(ControlSurface):
                 
                 # Determine the root based on the first part
                 current_item = None
-                if path_parts[0].lower() == "nstruments":
+                if path_parts[0].lower() == "instruments":
                     current_item = app.browser.instruments
                 elif path_parts[0].lower() == "sounds":
                     current_item = app.browser.sounds


### PR DESCRIPTION
## Summary
Fixes #74

Fixed typo in `AbletonMCP_Remote_Script/__init__.py`:
- Line 675: "nstruments" → "instruments"

## Type of Change
- [x] Bug fix (typo)

## Testing
- Verified the typo is fixed in the modified file
- This is a simple typo fix in a string comparison, no functional changes

This fix ensures that the instrument browser navigation works correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the instrument browser was not initializing correctly due to a path matching error. The browser now properly recognizes and initializes instrument selections as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->