### PR TITLE
Add get_notes_from_clip and delete_notes_from_clip tools

### DIFF
--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -226,10 +226,11 @@ class AbletonMCP(ControlSurface):
                 track_index = params.get("track_index", 0)
                 response["result"] = self._get_track_info(track_index)
             # Commands that modify Live's state should be scheduled on the main thread
-            elif command_type in ["create_midi_track", "set_track_name", 
-                                 "create_clip", "add_notes_to_clip", "set_clip_name", 
+            elif command_type in ["create_midi_track", "set_track_name",
+                                 "create_clip", "add_notes_to_clip", "set_clip_name",
                                  "set_tempo", "fire_clip", "stop_clip",
-                                 "start_playback", "stop_playback", "load_browser_item"]:
+                                 "start_playback", "stop_playback", "load_browser_item",
+                                 "delete_notes_from_clip"]:
                 # Use a thread-safe approach with a response queue
                 response_queue = queue.Queue()
                 
@@ -282,7 +283,11 @@ class AbletonMCP(ControlSurface):
                             track_index = params.get("track_index", 0)
                             item_uri = params.get("item_uri", "")
                             result = self._load_browser_item(track_index, item_uri)
-                        
+                        elif command_type == "delete_notes_from_clip":
+                            track_index = params.get("track_index", 0)
+                            clip_index = params.get("clip_index", 0)
+                            result = self._delete_notes_from_clip(track_index, clip_index)
+
                         # Put the result in the queue
                         response_queue.put({"status": "success", "result": result})
                     except Exception as e:
@@ -326,6 +331,10 @@ class AbletonMCP(ControlSurface):
             elif command_type == "get_browser_items_at_path":
                 path = params.get("path", "")
                 response["result"] = self.get_browser_items_at_path(path)
+            elif command_type == "get_notes_from_clip":
+                track_index = params.get("track_index", 0)
+                clip_index = params.get("clip_index", 0)
+                response["result"] = self._get_notes_from_clip(track_index, clip_index)
             else:
                 response["status"] = "error"
                 response["message"] = "Unknown command: " + command_type
@@ -1059,4 +1068,68 @@ class AbletonMCP(ControlSurface):
         except Exception as e:
             self.log_message("Error getting browser items at path: {0}".format(str(e)))
             self.log_message(traceback.format_exc())
+            raise
+
+    def _get_notes_from_clip(self, track_index, clip_index):
+        """Return all MIDI notes in a clip as a list of dicts."""
+        try:
+            if track_index < 0 or track_index >= len(self._song.tracks):
+                raise IndexError("Track index out of range")
+            track = self._song.tracks[track_index]
+            if clip_index < 0 or clip_index >= len(track.clip_slots):
+                raise IndexError("Clip index out of range")
+            clip_slot = track.clip_slots[clip_index]
+            if not clip_slot.has_clip:
+                raise Exception("No clip at track {0}, slot {1}".format(track_index, clip_index))
+            clip = clip_slot.clip
+            if not clip.is_midi_clip:
+                raise Exception("Clip is not a MIDI clip")
+
+            notes_raw = clip.get_notes(clip.loop_start, 0, clip.loop_end, 128)
+            notes = []
+            for n in notes_raw:
+                notes.append({
+                    "pitch": int(n[0]),
+                    "start_time": float(n[1]),
+                    "duration": float(n[2]),
+                    "velocity": int(n[3]),
+                    "mute": bool(n[4]),
+                })
+            notes.sort(key=lambda n: (n["start_time"], n["pitch"]))
+
+            return {
+                "track_index": track_index,
+                "clip_index": clip_index,
+                "clip_length": float(clip.length),
+                "note_count": len(notes),
+                "notes": notes,
+            }
+        except Exception as e:
+            self.log_message("Error getting notes from clip: " + str(e))
+            raise
+
+    def _delete_notes_from_clip(self, track_index, clip_index):
+        """Remove every MIDI note from a clip, leaving the clip intact."""
+        try:
+            if track_index < 0 or track_index >= len(self._song.tracks):
+                raise IndexError("Track index out of range")
+            track = self._song.tracks[track_index]
+            if clip_index < 0 or clip_index >= len(track.clip_slots):
+                raise IndexError("Clip index out of range")
+            clip_slot = track.clip_slots[clip_index]
+            if not clip_slot.has_clip:
+                raise Exception("No clip at track {0}, slot {1}".format(track_index, clip_index))
+            clip = clip_slot.clip
+            if not clip.is_midi_clip:
+                raise Exception("Clip is not a MIDI clip")
+
+            clip.remove_notes(clip.loop_start, 0, clip.loop_end, 128)
+
+            return {
+                "track_index": track_index,
+                "clip_index": clip_index,
+                "status": "all notes deleted",
+            }
+        except Exception as e:
+            self.log_message("Error deleting notes from clip: " + str(e))
             raise

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -651,6 +651,51 @@ def load_drum_kit(ctx: Context, track_index: int, rack_uri: str, kit_path: str) 
         logger.error(f"Error loading drum kit: {str(e)}")
         return f"Error loading drum kit: {str(e)}"
 
+@mcp.tool()
+def get_notes_from_clip(ctx: Context, track_index: int, clip_index: int) -> str:
+    """
+    Read all MIDI notes from a clip and return them as a list.
+
+    Parameters:
+    - track_index: The index of the track containing the clip
+    - clip_index: The index of the clip slot containing the clip
+
+    Each note has: pitch (0-127), start_time (beats), duration (beats), velocity (0-127), mute (bool).
+    Notes are sorted by start_time ascending.
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("get_notes_from_clip", {
+            "track_index": track_index,
+            "clip_index": clip_index,
+        })
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        logger.error(f"Error getting notes from clip: {str(e)}")
+        return f"Error getting notes from clip: {str(e)}"
+
+@mcp.tool()
+def delete_notes_from_clip(ctx: Context, track_index: int, clip_index: int) -> str:
+    """
+    Delete all MIDI notes from a clip without deleting the clip itself.
+
+    Parameters:
+    - track_index: The index of the track containing the clip
+    - clip_index: The index of the clip slot containing the clip
+
+    Use this before add_notes_to_clip when you want to fully replace the contents of a clip.
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("delete_notes_from_clip", {
+            "track_index": track_index,
+            "clip_index": clip_index,
+        })
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        logger.error(f"Error deleting notes from clip: {str(e)}")
+        return f"Error deleting notes from clip: {str(e)}"
+
 # Main execution
 def main():
     """Run the MCP server"""


### PR DESCRIPTION
## Summary

- Adds `get_notes_from_clip`: reads all MIDI notes from a clip, returning each note's pitch, start_time, duration, velocity, and mute — sorted by start time
- Adds `delete_notes_from_clip`: removes all MIDI notes from a clip without deleting the clip itself, enabling true overwrite when combined with `add_notes_to_clip`
- `delete_notes_from_clip` is correctly dispatched on Ableton's main thread (alongside `add_notes_to_clip`) since `clip.remove_notes()` mutates Live's state

## Test plan

- [ ] Create a MIDI clip with some notes
- [ ] Call `get_notes_from_clip` and verify notes are returned correctly
- [ ] Call `delete_notes_from_clip` and verify the clip is empty but still exists
- [ ] Call `add_notes_to_clip` after `delete_notes_from_clip` to confirm full overwrite works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Extract MIDI note information from clips, including pitch, timing, duration, velocity, and mute status
* Delete MIDI notes from clips in your Ableton session to easily modify your compositions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->