### PR TITLE
Add clip editing, mixer controls, scene launch, undo, and audio track support

### DIFF
--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -226,10 +226,13 @@ class AbletonMCP(ControlSurface):
                 track_index = params.get("track_index", 0)
                 response["result"] = self._get_track_info(track_index)
             # Commands that modify Live's state should be scheduled on the main thread
-            elif command_type in ["create_midi_track", "set_track_name", 
-                                 "create_clip", "add_notes_to_clip", "set_clip_name", 
+            elif command_type in ["create_midi_track", "set_track_name",
+                                 "create_clip", "add_notes_to_clip", "set_clip_name",
                                  "set_tempo", "fire_clip", "stop_clip",
-                                 "start_playback", "stop_playback", "load_browser_item"]:
+                                 "start_playback", "stop_playback", "load_browser_item",
+                                 "get_clip_notes", "remove_notes_from_clip", "delete_clip",
+                                 "duplicate_clip_to", "set_track_volume", "set_track_pan",
+                                 "set_track_send", "fire_scene", "create_audio_track", "undo"]:
                 # Use a thread-safe approach with a response queue
                 response_queue = queue.Queue()
                 
@@ -282,6 +285,48 @@ class AbletonMCP(ControlSurface):
                             track_index = params.get("track_index", 0)
                             item_uri = params.get("item_uri", "")
                             result = self._load_browser_item(track_index, item_uri)
+                        elif command_type == "get_clip_notes":
+                            track_index = params.get("track_index", 0)
+                            clip_index = params.get("clip_index", 0)
+                            result = self._get_clip_notes(track_index, clip_index)
+                        elif command_type == "remove_notes_from_clip":
+                            track_index = params.get("track_index", 0)
+                            clip_index = params.get("clip_index", 0)
+                            from_time = params.get("from_time", 0.0)
+                            from_pitch = params.get("from_pitch", 0)
+                            time_span = params.get("time_span", 99999.0)
+                            pitch_span = params.get("pitch_span", 128)
+                            result = self._remove_notes_from_clip(track_index, clip_index, from_time, from_pitch, time_span, pitch_span)
+                        elif command_type == "delete_clip":
+                            track_index = params.get("track_index", 0)
+                            clip_index = params.get("clip_index", 0)
+                            result = self._delete_clip(track_index, clip_index)
+                        elif command_type == "duplicate_clip_to":
+                            track_index = params.get("track_index", 0)
+                            clip_index = params.get("clip_index", 0)
+                            target_clip_index = params.get("target_clip_index", 0)
+                            result = self._duplicate_clip_to(track_index, clip_index, target_clip_index)
+                        elif command_type == "set_track_volume":
+                            track_index = params.get("track_index", 0)
+                            volume = params.get("volume", 0.85)
+                            result = self._set_track_volume(track_index, volume)
+                        elif command_type == "set_track_pan":
+                            track_index = params.get("track_index", 0)
+                            pan = params.get("pan", 0.0)
+                            result = self._set_track_pan(track_index, pan)
+                        elif command_type == "set_track_send":
+                            track_index = params.get("track_index", 0)
+                            send_index = params.get("send_index", 0)
+                            value = params.get("value", 0.0)
+                            result = self._set_track_send(track_index, send_index, value)
+                        elif command_type == "fire_scene":
+                            scene_index = params.get("scene_index", 0)
+                            result = self._fire_scene(scene_index)
+                        elif command_type == "create_audio_track":
+                            index = params.get("index", -1)
+                            result = self._create_audio_track(index)
+                        elif command_type == "undo":
+                            result = self._undo()
                         
                         # Put the result in the queue
                         response_queue.put({"status": "success", "result": result})
@@ -637,6 +682,248 @@ class AbletonMCP(ControlSurface):
             self.log_message("Error stopping playback: " + str(e))
             raise
     
+    def _get_clip_notes(self, track_index, clip_index):
+        """Get all notes from a clip"""
+        try:
+            if track_index < 0 or track_index >= len(self._song.tracks):
+                raise IndexError("Track index out of range")
+
+            track = self._song.tracks[track_index]
+
+            if clip_index < 0 or clip_index >= len(track.clip_slots):
+                raise IndexError("Clip index out of range")
+
+            clip_slot = track.clip_slots[clip_index]
+
+            if not clip_slot.has_clip:
+                raise Exception("No clip in slot")
+
+            clip = clip_slot.clip
+
+            # Get all notes from the clip
+            # get_notes(from_time, from_pitch, time_span, pitch_span)
+            notes_tuple = clip.get_notes(0.0, 0, clip.length, 128)
+
+            notes = []
+            for note in notes_tuple:
+                notes.append({
+                    "pitch": note[0],
+                    "start_time": note[1],
+                    "duration": note[2],
+                    "velocity": note[3],
+                    "mute": note[4]
+                })
+
+            result = {
+                "note_count": len(notes),
+                "clip_length": clip.length,
+                "notes": notes
+            }
+            return result
+        except Exception as e:
+            self.log_message("Error getting clip notes: " + str(e))
+            raise
+
+    def _remove_notes_from_clip(self, track_index, clip_index, from_time, from_pitch, time_span, pitch_span):
+        """Remove notes from a clip within the specified range"""
+        try:
+            if track_index < 0 or track_index >= len(self._song.tracks):
+                raise IndexError("Track index out of range")
+
+            track = self._song.tracks[track_index]
+
+            if clip_index < 0 or clip_index >= len(track.clip_slots):
+                raise IndexError("Clip index out of range")
+
+            clip_slot = track.clip_slots[clip_index]
+
+            if not clip_slot.has_clip:
+                raise Exception("No clip in slot")
+
+            clip = clip_slot.clip
+
+            # Remove notes in the specified range
+            clip.remove_notes(from_time, from_pitch, time_span, pitch_span)
+
+            result = {
+                "removed": True,
+                "from_time": from_time,
+                "from_pitch": from_pitch,
+                "time_span": time_span,
+                "pitch_span": pitch_span
+            }
+            return result
+        except Exception as e:
+            self.log_message("Error removing notes from clip: " + str(e))
+            raise
+
+    def _delete_clip(self, track_index, clip_index):
+        """Delete a clip from a clip slot"""
+        try:
+            if track_index < 0 or track_index >= len(self._song.tracks):
+                raise IndexError("Track index out of range")
+
+            track = self._song.tracks[track_index]
+
+            if clip_index < 0 or clip_index >= len(track.clip_slots):
+                raise IndexError("Clip index out of range")
+
+            clip_slot = track.clip_slots[clip_index]
+
+            if not clip_slot.has_clip:
+                raise Exception("No clip in slot")
+
+            clip_slot.delete_clip()
+
+            result = {
+                "deleted": True
+            }
+            return result
+        except Exception as e:
+            self.log_message("Error deleting clip: " + str(e))
+            raise
+
+    def _duplicate_clip_to(self, track_index, clip_index, target_clip_index):
+        """Duplicate a clip to another clip slot on the same track"""
+        try:
+            if track_index < 0 or track_index >= len(self._song.tracks):
+                raise IndexError("Track index out of range")
+
+            track = self._song.tracks[track_index]
+
+            if clip_index < 0 or clip_index >= len(track.clip_slots):
+                raise IndexError("Source clip index out of range")
+
+            if target_clip_index < 0 or target_clip_index >= len(track.clip_slots):
+                raise IndexError("Target clip index out of range")
+
+            source_slot = track.clip_slots[clip_index]
+            target_slot = track.clip_slots[target_clip_index]
+
+            if not source_slot.has_clip:
+                raise Exception("No clip in source slot")
+
+            if target_slot.has_clip:
+                raise Exception("Target slot already has a clip")
+
+            source_slot.duplicate_clip_to(target_slot)
+
+            result = {
+                "duplicated": True,
+                "source_slot": clip_index,
+                "target_slot": target_clip_index
+            }
+            return result
+        except Exception as e:
+            self.log_message("Error duplicating clip: " + str(e))
+            raise
+
+    def _set_track_volume(self, track_index, volume):
+        """Set the volume of a track (0.0 to 1.0)"""
+        try:
+            if track_index < 0 or track_index >= len(self._song.tracks):
+                raise IndexError("Track index out of range")
+
+            track = self._song.tracks[track_index]
+            track.mixer_device.volume.value = max(0.0, min(1.0, volume))
+
+            result = {
+                "volume": track.mixer_device.volume.value
+            }
+            return result
+        except Exception as e:
+            self.log_message("Error setting track volume: " + str(e))
+            raise
+
+    def _set_track_pan(self, track_index, pan):
+        """Set the panning of a track (-1.0 to 1.0)"""
+        try:
+            if track_index < 0 or track_index >= len(self._song.tracks):
+                raise IndexError("Track index out of range")
+
+            track = self._song.tracks[track_index]
+            track.mixer_device.panning.value = max(-1.0, min(1.0, pan))
+
+            result = {
+                "panning": track.mixer_device.panning.value
+            }
+            return result
+        except Exception as e:
+            self.log_message("Error setting track panning: " + str(e))
+            raise
+
+    def _set_track_send(self, track_index, send_index, value):
+        """Set a send amount on a track (0.0 to 1.0)"""
+        try:
+            if track_index < 0 or track_index >= len(self._song.tracks):
+                raise IndexError("Track index out of range")
+
+            track = self._song.tracks[track_index]
+            sends = track.mixer_device.sends
+
+            if send_index < 0 or send_index >= len(sends):
+                raise IndexError("Send index out of range (track has {0} sends)".format(len(sends)))
+
+            sends[send_index].value = max(0.0, min(1.0, value))
+
+            result = {
+                "send_index": send_index,
+                "value": sends[send_index].value
+            }
+            return result
+        except Exception as e:
+            self.log_message("Error setting track send: " + str(e))
+            raise
+
+    def _fire_scene(self, scene_index):
+        """Fire (launch) a scene, triggering all clips in that row"""
+        try:
+            scenes = self._song.scenes
+            if scene_index < 0 or scene_index >= len(scenes):
+                raise IndexError("Scene index out of range (session has {0} scenes)".format(len(scenes)))
+
+            scenes[scene_index].fire()
+
+            result = {
+                "fired": True,
+                "scene_index": scene_index,
+                "scene_name": scenes[scene_index].name
+            }
+            return result
+        except Exception as e:
+            self.log_message("Error firing scene: " + str(e))
+            raise
+
+    def _create_audio_track(self, index):
+        """Create a new audio track at the specified index"""
+        try:
+            self._song.create_audio_track(index)
+
+            new_track_index = len(self._song.tracks) - 1 if index == -1 else index
+            new_track = self._song.tracks[new_track_index]
+
+            result = {
+                "index": new_track_index,
+                "name": new_track.name
+            }
+            return result
+        except Exception as e:
+            self.log_message("Error creating audio track: " + str(e))
+            raise
+
+    def _undo(self):
+        """Undo the last action"""
+        try:
+            self._song.undo()
+
+            result = {
+                "undone": True
+            }
+            return result
+        except Exception as e:
+            self.log_message("Error undoing: " + str(e))
+            raise
+
     def _get_browser_item(self, uri, path):
         """Get a browser item by URI or path"""
         try:

--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -225,20 +225,31 @@ class AbletonMCP(ControlSurface):
             elif command_type == "get_track_info":
                 track_index = params.get("track_index", 0)
                 response["result"] = self._get_track_info(track_index)
+            elif command_type == "get_clip_notes":
+                # Read-only operation, safe to execute directly like get_track_info
+                track_index = params.get("track_index", 0)
+                clip_index = params.get("clip_index", 0)
+                response["result"] = self._get_clip_notes(track_index, clip_index)
             # Commands that modify Live's state should be scheduled on the main thread
             elif command_type in ["create_midi_track", "set_track_name",
                                  "create_clip", "add_notes_to_clip", "set_clip_name",
                                  "set_tempo", "fire_clip", "stop_clip",
                                  "start_playback", "stop_playback", "load_browser_item",
-                                 "get_clip_notes", "remove_notes_from_clip", "delete_clip",
+                                 "remove_notes_from_clip", "delete_clip",
                                  "duplicate_clip_to", "set_track_volume", "set_track_pan",
                                  "set_track_send", "fire_scene", "create_audio_track", "undo"]:
                 # Use a thread-safe approach with a response queue
                 response_queue = queue.Queue()
-                
+                # Cancellation flag: if the wait times out, prevent late execution
+                # of destructive operations that haven't started yet
+                cancelled = [False]
+
                 # Define a function to execute on the main thread
                 def main_thread_task():
                     try:
+                        if cancelled[0]:
+                            self.log_message("Skipping cancelled command: " + command_type)
+                            return
                         result = None
                         if command_type == "create_midi_track":
                             index = params.get("index", -1)
@@ -285,10 +296,6 @@ class AbletonMCP(ControlSurface):
                             track_index = params.get("track_index", 0)
                             item_uri = params.get("item_uri", "")
                             result = self._load_browser_item(track_index, item_uri)
-                        elif command_type == "get_clip_notes":
-                            track_index = params.get("track_index", 0)
-                            clip_index = params.get("clip_index", 0)
-                            result = self._get_clip_notes(track_index, clip_index)
                         elif command_type == "remove_notes_from_clip":
                             track_index = params.get("track_index", 0)
                             clip_index = params.get("clip_index", 0)
@@ -351,8 +358,10 @@ class AbletonMCP(ControlSurface):
                     else:
                         response["result"] = task_response.get("result", {})
                 except queue.Empty:
+                    cancelled[0] = True
+                    self.log_message("Timeout for command: " + command_type + " - marking cancelled")
                     response["status"] = "error"
-                    response["message"] = "Timeout waiting for operation to complete"
+                    response["message"] = "Timeout waiting for operation to complete. The operation was cancelled to prevent unintended side effects."
             elif command_type == "get_browser_item":
                 uri = params.get("uri", None)
                 path = params.get("path", None)

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -105,7 +105,7 @@ class AbletonConnection:
             "create_midi_track", "create_audio_track", "set_track_name",
             "create_clip", "add_notes_to_clip", "set_clip_name",
             "set_tempo", "fire_clip", "stop_clip", "set_device_parameter",
-            "start_playback", "stop_playback", "load_instrument_or_effect",
+            "start_playback", "stop_playback", "load_browser_item",
             "remove_notes_from_clip", "delete_clip",
             "duplicate_clip_to", "set_track_volume", "set_track_pan",
             "set_track_send", "fire_scene", "undo"

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -105,7 +105,10 @@ class AbletonConnection:
             "create_midi_track", "create_audio_track", "set_track_name",
             "create_clip", "add_notes_to_clip", "set_clip_name",
             "set_tempo", "fire_clip", "stop_clip", "set_device_parameter",
-            "start_playback", "stop_playback", "load_instrument_or_effect"
+            "start_playback", "stop_playback", "load_instrument_or_effect",
+            "get_clip_notes", "remove_notes_from_clip", "delete_clip",
+            "duplicate_clip_to", "set_track_volume", "set_track_pan",
+            "set_track_send", "fire_scene", "undo"
         ]
         
         try:
@@ -497,6 +500,215 @@ def stop_playback(ctx: Context) -> str:
     except Exception as e:
         logger.error(f"Error stopping playback: {str(e)}")
         return f"Error stopping playback: {str(e)}"
+
+@mcp.tool()
+def get_clip_notes(ctx: Context, track_index: int, clip_index: int) -> str:
+    """
+    Get all MIDI notes from a clip.
+
+    Parameters:
+    - track_index: The index of the track containing the clip
+    - clip_index: The index of the clip slot containing the clip
+
+    Returns note data including pitch, start_time, duration, velocity, and mute for each note.
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("get_clip_notes", {
+            "track_index": track_index,
+            "clip_index": clip_index
+        })
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        logger.error(f"Error getting clip notes: {str(e)}")
+        return f"Error getting clip notes: {str(e)}"
+
+@mcp.tool()
+def remove_notes_from_clip(
+    ctx: Context,
+    track_index: int,
+    clip_index: int,
+    from_time: float = 0.0,
+    from_pitch: int = 0,
+    time_span: float = 99999.0,
+    pitch_span: int = 128
+) -> str:
+    """
+    Remove MIDI notes from a clip within a specified range.
+    By default removes ALL notes. Use parameters to target specific ranges.
+
+    Parameters:
+    - track_index: The index of the track containing the clip
+    - clip_index: The index of the clip slot containing the clip
+    - from_time: Start time in beats (default: 0.0 = beginning)
+    - from_pitch: Lowest MIDI pitch to remove (default: 0)
+    - time_span: Duration in beats to clear (default: 99999.0 = all)
+    - pitch_span: Number of pitches above from_pitch to clear (default: 128 = all)
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("remove_notes_from_clip", {
+            "track_index": track_index,
+            "clip_index": clip_index,
+            "from_time": from_time,
+            "from_pitch": from_pitch,
+            "time_span": time_span,
+            "pitch_span": pitch_span
+        })
+        return f"Removed notes from clip at track {track_index}, slot {clip_index}"
+    except Exception as e:
+        logger.error(f"Error removing notes from clip: {str(e)}")
+        return f"Error removing notes from clip: {str(e)}"
+
+@mcp.tool()
+def delete_clip(ctx: Context, track_index: int, clip_index: int) -> str:
+    """
+    Delete a clip from a clip slot, leaving the slot empty.
+
+    Parameters:
+    - track_index: The index of the track containing the clip
+    - clip_index: The index of the clip slot to clear
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("delete_clip", {
+            "track_index": track_index,
+            "clip_index": clip_index
+        })
+        return f"Deleted clip at track {track_index}, slot {clip_index}"
+    except Exception as e:
+        logger.error(f"Error deleting clip: {str(e)}")
+        return f"Error deleting clip: {str(e)}"
+
+@mcp.tool()
+def duplicate_clip_to(ctx: Context, track_index: int, clip_index: int, target_clip_index: int) -> str:
+    """
+    Duplicate a clip to another clip slot on the same track.
+
+    Parameters:
+    - track_index: The index of the track containing the clip
+    - clip_index: The source clip slot index
+    - target_clip_index: The destination clip slot index (must be empty)
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("duplicate_clip_to", {
+            "track_index": track_index,
+            "clip_index": clip_index,
+            "target_clip_index": target_clip_index
+        })
+        return f"Duplicated clip from slot {clip_index} to slot {target_clip_index} on track {track_index}"
+    except Exception as e:
+        logger.error(f"Error duplicating clip: {str(e)}")
+        return f"Error duplicating clip: {str(e)}"
+
+@mcp.tool()
+def set_track_volume(ctx: Context, track_index: int, volume: float) -> str:
+    """
+    Set the volume of a track.
+
+    Parameters:
+    - track_index: The index of the track
+    - volume: Volume level from 0.0 (silent) to 1.0 (max). Default is ~0.85.
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("set_track_volume", {
+            "track_index": track_index,
+            "volume": volume
+        })
+        return f"Set track {track_index} volume to {result.get('volume', volume)}"
+    except Exception as e:
+        logger.error(f"Error setting track volume: {str(e)}")
+        return f"Error setting track volume: {str(e)}"
+
+@mcp.tool()
+def set_track_pan(ctx: Context, track_index: int, pan: float) -> str:
+    """
+    Set the panning of a track.
+
+    Parameters:
+    - track_index: The index of the track
+    - pan: Panning from -1.0 (full left) to 1.0 (full right). 0.0 is center.
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("set_track_pan", {
+            "track_index": track_index,
+            "pan": pan
+        })
+        return f"Set track {track_index} panning to {result.get('panning', pan)}"
+    except Exception as e:
+        logger.error(f"Error setting track panning: {str(e)}")
+        return f"Error setting track panning: {str(e)}"
+
+@mcp.tool()
+def set_track_send(ctx: Context, track_index: int, send_index: int, value: float) -> str:
+    """
+    Set a send amount on a track (for routing to return tracks).
+
+    Parameters:
+    - track_index: The index of the track
+    - send_index: The index of the send (0 = Send A, 1 = Send B, etc.)
+    - value: Send amount from 0.0 (none) to 1.0 (full)
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("set_track_send", {
+            "track_index": track_index,
+            "send_index": send_index,
+            "value": value
+        })
+        return f"Set track {track_index} send {send_index} to {result.get('value', value)}"
+    except Exception as e:
+        logger.error(f"Error setting track send: {str(e)}")
+        return f"Error setting track send: {str(e)}"
+
+@mcp.tool()
+def fire_scene(ctx: Context, scene_index: int) -> str:
+    """
+    Fire (launch) a scene, triggering all clips in that row across all tracks.
+
+    Parameters:
+    - scene_index: The index of the scene to fire (0-based)
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("fire_scene", {
+            "scene_index": scene_index
+        })
+        scene_name = result.get('scene_name', '')
+        return f"Fired scene {scene_index}" + (f" ({scene_name})" if scene_name else "")
+    except Exception as e:
+        logger.error(f"Error firing scene: {str(e)}")
+        return f"Error firing scene: {str(e)}"
+
+@mcp.tool()
+def create_audio_track(ctx: Context, index: int = -1) -> str:
+    """
+    Create a new audio track in the Ableton session.
+
+    Parameters:
+    - index: The index to insert the track at (-1 = end of list)
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("create_audio_track", {"index": index})
+        return f"Created new audio track: {result.get('name', 'unknown')}"
+    except Exception as e:
+        logger.error(f"Error creating audio track: {str(e)}")
+        return f"Error creating audio track: {str(e)}"
+
+@mcp.tool()
+def undo(ctx: Context) -> str:
+    """Undo the last action in Ableton."""
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("undo")
+        return "Undid last action"
+    except Exception as e:
+        logger.error(f"Error undoing: {str(e)}")
+        return f"Error undoing: {str(e)}"
 
 @mcp.tool()
 def get_browser_tree(ctx: Context, category_type: str = "all") -> str:

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -106,7 +106,7 @@ class AbletonConnection:
             "create_clip", "add_notes_to_clip", "set_clip_name",
             "set_tempo", "fire_clip", "stop_clip", "set_device_parameter",
             "start_playback", "stop_playback", "load_instrument_or_effect",
-            "get_clip_notes", "remove_notes_from_clip", "delete_clip",
+            "remove_notes_from_clip", "delete_clip",
             "duplicate_clip_to", "set_track_volume", "set_track_pan",
             "set_track_send", "fire_scene", "undo"
         ]


### PR DESCRIPTION
## Summary

- **Clip editing**: `get_clip_notes`, `remove_notes_from_clip`, `delete_clip`, `duplicate_clip_to` - enables reading notes back, clearing/editing clips, and duplicating for variations
- **Mixer controls**: `set_track_volume`, `set_track_pan`, `set_track_send` - allows mixing directly via MCP
- **Session management**: `fire_scene` (launch entire scene rows), `create_audio_track` (was referenced but unimplemented), `undo`

These 11 new tools address workflow gaps discovered while using this already awesome MCP for composition sessions. The biggest pain points were:
1. No way to read or edit notes in existing clips (had to create new clips instead of fixing)
2. No way to delete clips (slots accumulate)  
3. No mixer control (could read volume/pan but not set them)
4. No scene launching (couldn't fire both tracks simultaneously)

All new handlers follow the existing patterns: Remote Script methods with main-thread scheduling, MCP server tool endpoints with proper error handling, and command routing in both `_process_command` and `is_modifying_command`.

## Test plan

- [ ] Verify `get_clip_notes` returns correct note data from an existing clip
- [ ] Verify `remove_notes_from_clip` clears all notes (default params) and targeted ranges
- [ ] Verify `delete_clip` removes a clip and leaves the slot empty
- [ ] Verify `duplicate_clip_to` copies clip to an empty target slot
- [ ] Verify `set_track_volume` and `set_track_pan` update mixer values
- [ ] Verify `set_track_send` routes to return tracks
- [ ] Verify `fire_scene` launches all clips in a scene row
- [ ] Verify `create_audio_track` creates a track (was previously a dead code path)
- [ ] Verify `undo` reverses the last action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve clip notes with note count, length, and note details.
  * Remove notes from a clip, delete clips, and duplicate clips between slots.
  * Adjust track volume, pan, and send levels.
  * Launch scenes and report scene names.
  * Create new audio tracks and return their names/indices.
  * Undo the last action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->