### PR TITLE
Add macro and device parameter support

### DIFF
--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -225,11 +225,15 @@ class AbletonMCP(ControlSurface):
             elif command_type == "get_track_info":
                 track_index = params.get("track_index", 0)
                 response["result"] = self._get_track_info(track_index)
+            elif command_type == "get_track_devices":
+                track_index = params.get("track_index", 0)
+                response["result"] = self._get_track_devices(track_index)
             # Commands that modify Live's state should be scheduled on the main thread
-            elif command_type in ["create_midi_track", "set_track_name", 
-                                 "create_clip", "add_notes_to_clip", "set_clip_name", 
+            elif command_type in ["create_midi_track", "set_track_name",
+                                 "create_clip", "add_notes_to_clip", "set_clip_name",
                                  "set_tempo", "fire_clip", "stop_clip",
-                                 "start_playback", "stop_playback", "load_browser_item"]:
+                                 "start_playback", "stop_playback", "load_browser_item",
+                                 "set_device_parameter"]:
                 # Use a thread-safe approach with a response queue
                 response_queue = queue.Queue()
                 
@@ -282,7 +286,13 @@ class AbletonMCP(ControlSurface):
                             track_index = params.get("track_index", 0)
                             item_uri = params.get("item_uri", "")
                             result = self._load_browser_item(track_index, item_uri)
-                        
+                        elif command_type == "set_device_parameter":
+                            track_index = params.get("track_index", 0)
+                            device_index = params.get("device_index", 0)
+                            parameter_index = params.get("parameter_index", 0)
+                            value = params.get("value", 0.0)
+                            result = self._set_device_parameter(track_index, device_index, parameter_index, value)
+
                         # Put the result in the queue
                         response_queue.put({"status": "success", "result": result})
                     except Exception as e:
@@ -413,7 +423,70 @@ class AbletonMCP(ControlSurface):
         except Exception as e:
             self.log_message("Error getting track info: " + str(e))
             raise
-    
+
+    def _get_track_devices(self, track_index):
+        """Get all devices on a track with their parameters (including macros)"""
+        try:
+            if track_index < 0 or track_index >= len(self._song.tracks):
+                raise IndexError("Track index out of range")
+
+            track = self._song.tracks[track_index]
+            devices = []
+
+            for device_index, device in enumerate(track.devices):
+                parameters = []
+                for param_index, param in enumerate(device.parameters):
+                    parameters.append({
+                        "index": param_index,
+                        "name": param.name,
+                        "value": param.value,
+                        "min": param.min,
+                        "max": param.max,
+                        "is_quantized": param.is_quantized
+                    })
+
+                devices.append({
+                    "index": device_index,
+                    "name": device.name,
+                    "class_name": device.class_name,
+                    "type": self._get_device_type(device),
+                    "parameters": parameters
+                })
+
+            return {"track_index": track_index, "devices": devices}
+        except Exception as e:
+            self.log_message("Error getting track devices: " + str(e))
+            raise
+
+    def _set_device_parameter(self, track_index, device_index, parameter_index, value):
+        """Set a parameter value on a device (works for macros and any other parameter)"""
+        try:
+            if track_index < 0 or track_index >= len(self._song.tracks):
+                raise IndexError("Track index out of range")
+
+            track = self._song.tracks[track_index]
+
+            if device_index < 0 or device_index >= len(track.devices):
+                raise IndexError("Device index out of range")
+
+            device = track.devices[device_index]
+
+            if parameter_index < 0 or parameter_index >= len(device.parameters):
+                raise IndexError("Parameter index out of range")
+
+            param = device.parameters[parameter_index]
+            clamped_value = max(param.min, min(param.max, value))
+            param.value = clamped_value
+
+            return {
+                "device_name": device.name,
+                "parameter_name": param.name,
+                "value": param.value
+            }
+        except Exception as e:
+            self.log_message("Error setting device parameter: " + str(e))
+            raise
+
     def _create_midi_track(self, index):
         """Create a new MIDI track at the specified index"""
         try:

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -105,7 +105,8 @@ class AbletonConnection:
             "create_midi_track", "create_audio_track", "set_track_name",
             "create_clip", "add_notes_to_clip", "set_clip_name",
             "set_tempo", "fire_clip", "stop_clip", "set_device_parameter",
-            "start_playback", "stop_playback", "load_instrument_or_effect"
+            "start_playback", "stop_playback", "load_instrument_or_effect",
+            "load_browser_item"
         ]
         
         try:
@@ -497,6 +498,56 @@ def stop_playback(ctx: Context) -> str:
     except Exception as e:
         logger.error(f"Error stopping playback: {str(e)}")
         return f"Error stopping playback: {str(e)}"
+
+@mcp.tool()
+def get_track_devices(ctx: Context, track_index: int) -> str:
+    """
+    Get all devices on a track along with their parameters and current values.
+    For rack devices this includes all macro knobs (Macro 1–8).
+
+    Parameters:
+    - track_index: The index of the track to inspect
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("get_track_devices", {"track_index": track_index})
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        logger.error(f"Error getting track devices: {str(e)}")
+        return f"Error getting track devices: {str(e)}"
+
+@mcp.tool()
+def set_device_parameter(
+    ctx: Context,
+    track_index: int,
+    device_index: int,
+    parameter_index: int,
+    value: float
+) -> str:
+    """
+    Set a parameter value on a device. Use get_track_devices first to find the
+    correct device_index and parameter_index. For rack devices the macro knobs
+    are parameter indices 1–8 (index 0 is the Device On/Off toggle).
+
+    Parameters:
+    - track_index: The index of the track containing the device
+    - device_index: The index of the device on the track
+    - parameter_index: The index of the parameter to set
+    - value: The new value (will be clamped to the parameter's min/max range)
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("set_device_parameter", {
+            "track_index": track_index,
+            "device_index": device_index,
+            "parameter_index": parameter_index,
+            "value": value
+        })
+        return (f"Set '{result.get('parameter_name')}' on '{result.get('device_name')}' "
+                f"to {result.get('value')}")
+    except Exception as e:
+        logger.error(f"Error setting device parameter: {str(e)}")
+        return f"Error setting device parameter: {str(e)}"
 
 @mcp.tool()
 def get_browser_tree(ctx: Context, category_type: str = "all") -> str:


### PR DESCRIPTION
## Summary

- Adds `get_track_devices` — returns every device on a track with its full parameter list (name, value, min, max). For rack devices this exposes all macro knobs.
- Adds `set_device_parameter` — sets any device parameter by index, including rack macro knobs (indices 1-8, where index 0 is Device On/Off). Value is clamped to the parameter min/max range.

## How it works

Ask Claude things like:
- "Show me the macros on track 2" → calls `get_track_devices`
- "Set the Filter Cutoff macro on track 2 to 80" → calls `set_device_parameter`

## Test plan

- [ ] Load an Instrument Rack on a MIDI track and call `get_track_devices`, verify macro names and values are returned
- [ ] Call `set_device_parameter` with a macro index and confirm the knob moves in Ableton
- [ ] Verify out-of-range values are clamped correctly
- [ ] Confirm non-rack devices (e.g. Reverb) also expose their parameters correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added device inspection capability to retrieve all devices and parameters on a specified track, including rack macro knobs with range and quantization metadata
  * Added device parameter control to set parameter values with automatic validation and value clamping to allowed bounds, returning confirmation of updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->