### PR TITLE
Fix load_browser_item for plugin URIs

### DIFF
--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -758,6 +758,34 @@ class AbletonMCP(ControlSurface):
             self.log_message(traceback.format_exc())
             raise
     
+    # Substring markers that point a URI at a likely root. If no marker
+    # matches we fall back to the default order, so this is purely an
+    # optimisation — never a correctness change.
+    _URI_ROOT_HINTS = (
+        ('plugins',       ('vst:', 'vst3:', 'au:', 'query:plugins', 'plugin#')),
+        ('max_for_live',  ('max for live', 'maxforlive', 'm4l', 'query:max')),
+        ('user_library',  ('user library', 'userlibrary', 'query:user library', 'query:user-library')),
+        ('packs',         ('query:packs', '/packs/')),
+        ('samples',       ('query:samples', 'sample:', '/samples/')),
+        ('drums',         ('query:drums', '/drums/')),
+        ('instruments',   ('query:instruments', '/instruments/')),
+        ('sounds',        ('query:sounds', '/sounds/')),
+        ('audio_effects', ('query:audio effects', 'audioeffects', '/audio_effects/')),
+        ('midi_effects',  ('query:midi effects', 'midieffects', '/midi_effects/')),
+    )
+
+    def _order_roots_by_uri(self, roots, uri):
+        """Reorder ``roots`` so the URI's likely root is walked first."""
+        if not isinstance(uri, (bytes, str)) or not uri:
+            return roots
+        lowered = uri.lower()
+        for attr, markers in self._URI_ROOT_HINTS:
+            if any(m in lowered for m in markers):
+                head = [(a, r) for (a, r) in roots if a == attr]
+                tail = [(a, r) for (a, r) in roots if a != attr]
+                return head + tail
+        return roots
+
     def _find_browser_item_by_uri(self, browser_or_item, uri, max_depth=10, current_depth=0):
         """Find a browser item by its URI.
 
@@ -789,24 +817,21 @@ class AbletonMCP(ControlSurface):
 
             # Check if this is a browser with root categories
             if hasattr(browser_or_item, 'instruments'):
-                # Check all main categories
-                categories = [
-                    browser_or_item.instruments,
-                    browser_or_item.sounds,
-                    browser_or_item.drums,
-                    browser_or_item.audio_effects,
-                    browser_or_item.midi_effects
+                roots = [
+                    ('instruments', browser_or_item.instruments),
+                    ('sounds', browser_or_item.sounds),
+                    ('drums', browser_or_item.drums),
+                    ('audio_effects', browser_or_item.audio_effects),
+                    ('midi_effects', browser_or_item.midi_effects),
                 ]
-                # Walk plugins / max_for_live / user_library / packs / samples
-                # so URIs from get_browser_items_at_path for plugins actually load.
                 for extra_attr in ('plugins', 'max_for_live', 'user_library', 'packs', 'samples'):
                     if hasattr(browser_or_item, extra_attr):
                         try:
-                            categories.append(getattr(browser_or_item, extra_attr))
+                            roots.append((extra_attr, getattr(browser_or_item, extra_attr)))
                         except (AttributeError, RuntimeError) as e:
                             self.log_message("Could not access browser.{0}: {1}".format(extra_attr, str(e)))
 
-                for category in categories:
+                for _attr, category in self._order_roots_by_uri(roots, uri):
                     item = self._find_browser_item_by_uri(category, uri, max_depth, current_depth + 1)
                     if item:
                         return item

--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -759,16 +759,34 @@ class AbletonMCP(ControlSurface):
             raise
     
     def _find_browser_item_by_uri(self, browser_or_item, uri, max_depth=10, current_depth=0):
-        """Find a browser item by its URI"""
+        """Find a browser item by its URI.
+
+        Top-level lookups are memoised on ``self._uri_cache`` so repeated
+        loads of the same URI don't re-walk the entire browser tree.
+        """
+        if current_depth == 0:
+            cache = getattr(self, '_uri_cache', None)
+            if cache is None:
+                self._uri_cache = cache = {}
+            if uri in cache:
+                return cache[uri]
+            result = self._walk_browser_for_uri(browser_or_item, uri, max_depth, 0)
+            if result is not None:
+                cache[uri] = result
+            return result
+        return self._walk_browser_for_uri(browser_or_item, uri, max_depth, current_depth)
+
+    def _walk_browser_for_uri(self, browser_or_item, uri, max_depth, current_depth):
+        """Recursive walk used by :py:meth:`_find_browser_item_by_uri`."""
         try:
             # Check if this is the item we're looking for
             if hasattr(browser_or_item, 'uri') and browser_or_item.uri == uri:
                 return browser_or_item
-            
+
             # Stop recursion if we've reached max depth
             if current_depth >= max_depth:
                 return None
-            
+
             # Check if this is a browser with root categories
             if hasattr(browser_or_item, 'instruments'):
                 # Check all main categories
@@ -779,21 +797,29 @@ class AbletonMCP(ControlSurface):
                     browser_or_item.audio_effects,
                     browser_or_item.midi_effects
                 ]
-                
+                # Walk plugins / max_for_live / user_library / packs / samples
+                # so URIs from get_browser_items_at_path for plugins actually load.
+                for extra_attr in ('plugins', 'max_for_live', 'user_library', 'packs', 'samples'):
+                    if hasattr(browser_or_item, extra_attr):
+                        try:
+                            categories.append(getattr(browser_or_item, extra_attr))
+                        except (AttributeError, RuntimeError) as e:
+                            self.log_message("Could not access browser.{0}: {1}".format(extra_attr, str(e)))
+
                 for category in categories:
                     item = self._find_browser_item_by_uri(category, uri, max_depth, current_depth + 1)
                     if item:
                         return item
-                
+
                 return None
-            
+
             # Check if this item has children
             if hasattr(browser_or_item, 'children') and browser_or_item.children:
                 for child in browser_or_item.children:
                     item = self._find_browser_item_by_uri(child, uri, max_depth, current_depth + 1)
                     if item:
                         return item
-            
+
             return None
         except Exception as e:
             self.log_message("Error finding browser item by URI: {0}".format(str(e)))


### PR DESCRIPTION
Closes #79, addresses #47.

Found this while loading a VST3 plugin onto a track via the bridge.

### Repro

1. `get_browser_items_at_path("Plugins/VST3/<Vendor>/<Plugin>")` returns a URI like `query:Plugins#VST3:Native%20Instruments:Massive%20X`.
2. Pass that URI to `load_browser_item` (or the `load_instrument_or_effect` wrapper).
3. Fails with `Browser item with URI '...' not found`.

### Cause

`_find_browser_item_by_uri` only walks `instruments / sounds / drums / audio_effects / midi_effects`. It never visits `app.browser.plugins` (or `max_for_live / user_library / packs / samples`), so URIs from those categories always return `None` — even though `get_browser_items_at_path` can navigate into them fine.

### Fix

Append `plugins / max_for_live / user_library / packs / samples` to the walked categories list, hasattr-guarded for Live-version safety. URI lookup now matches the surface `get_browser_items_at_path` already exposes.

### After

- Native instrument URIs still load (e.g. `query:Synths#Operator`).
- Native audio FX URIs still load (e.g. `query:AudioFx#Auto%20Filter`).
- VST3 / AU plugin URIs load for the first time. Verified by loading Massive X VST3 on Live 12 Suite, macOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Browser search now covers plugins, Max for Live, user library, packs, and samples alongside top-level categories for more reliable item resolution.
* **Performance**
  * Added caching of top-level URI lookups to reduce repeated full-browser traversals and speed subsequent resolutions.
* **Refactor**
  * Traversal logic reorganized to enforce search depth and prioritize likely root locations for more consistent results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ahujasid/ableton-mcp/pull/93?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->