### PR TITLE
Add return_track / duplicate_track / capture_midi / tap_tempo / set_track_color

### DIFF
--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -226,10 +226,12 @@ class AbletonMCP(ControlSurface):
                 track_index = params.get("track_index", 0)
                 response["result"] = self._get_track_info(track_index)
             # Commands that modify Live's state should be scheduled on the main thread
-            elif command_type in ["create_midi_track", "set_track_name", 
-                                 "create_clip", "add_notes_to_clip", "set_clip_name", 
+            elif command_type in ["create_midi_track", "set_track_name",
+                                 "create_clip", "add_notes_to_clip", "set_clip_name",
                                  "set_tempo", "fire_clip", "stop_clip",
-                                 "start_playback", "stop_playback", "load_browser_item"]:
+                                 "start_playback", "stop_playback", "load_browser_item",
+                                 "create_return_track", "duplicate_track",
+                                 "capture_midi", "tap_tempo", "set_track_color"]:
                 # Use a thread-safe approach with a response queue
                 response_queue = queue.Queue()
                 
@@ -282,7 +284,21 @@ class AbletonMCP(ControlSurface):
                             track_index = params.get("track_index", 0)
                             item_uri = params.get("item_uri", "")
                             result = self._load_browser_item(track_index, item_uri)
-                        
+                        elif command_type == "create_return_track":
+                            result = self._create_return_track()
+                        elif command_type == "duplicate_track":
+                            track_index = params.get("track_index", 0)
+                            result = self._duplicate_track(track_index)
+                        elif command_type == "capture_midi":
+                            result = self._capture_midi()
+                        elif command_type == "tap_tempo":
+                            result = self._tap_tempo()
+                        elif command_type == "set_track_color":
+                            track_index = params.get("track_index", 0)
+                            color_index = params.get("color_index", -1)
+                            color = params.get("color", -1)
+                            result = self._set_track_color(track_index, color_index, color)
+
                         # Put the result in the queue
                         response_queue.put({"status": "success", "result": result})
                     except Exception as e:
@@ -628,7 +644,7 @@ class AbletonMCP(ControlSurface):
         """Stop playing the session"""
         try:
             self._song.stop_playing()
-            
+
             result = {
                 "playing": self._song.is_playing
             }
@@ -636,7 +652,83 @@ class AbletonMCP(ControlSurface):
         except Exception as e:
             self.log_message("Error stopping playback: " + str(e))
             raise
-    
+
+    def _create_return_track(self):
+        """Create a return track at the end. Returns its index."""
+        try:
+            self._song.create_return_track()
+            n = len(self._song.return_tracks)
+            return {
+                "created": True,
+                "return_track_index": n - 1,
+                "return_track_count": n,
+            }
+        except Exception as e:
+            self.log_message("Error creating return track: " + str(e))
+            raise
+
+    def _duplicate_track(self, track_index):
+        """Duplicate a track (devices + clips). New track appears at track_index + 1."""
+        try:
+            if track_index < 0 or track_index >= len(self._song.tracks):
+                raise IndexError("Track index out of range")
+            self._song.duplicate_track(track_index)
+            return {
+                "duplicated": True,
+                "source_track_index": track_index,
+                "new_track_index": track_index + 1,
+                "track_count": len(self._song.tracks),
+            }
+        except Exception as e:
+            self.log_message("Error duplicating track: " + str(e))
+            raise
+
+    def _capture_midi(self):
+        """Trigger Live's MIDI Capture — recovers MIDI played in the recent past."""
+        try:
+            self._song.capture_midi()
+            return {"captured": True}
+        except Exception as e:
+            self.log_message("Error capturing MIDI: " + str(e))
+            raise
+
+    def _tap_tempo(self):
+        """Register a tap-tempo tap. Live gradually settles to the tap interval."""
+        try:
+            self._song.tap_tempo()
+            return {"tapped": True, "tempo": self._song.tempo}
+        except Exception as e:
+            self.log_message("Error tapping tempo: " + str(e))
+            raise
+
+    def _set_track_color(self, track_index, color_index, color):
+        """Set track color.
+
+        ``color_index`` is the preferred Live 10+ palette index (0-69).
+        ``color`` (RGB integer 0xRRGGBB) is the legacy fallback.
+        Pass -1 for whichever you're not using.
+        """
+        try:
+            if track_index < 0 or track_index >= len(self._song.tracks):
+                raise IndexError("Track index out of range")
+            track = self._song.tracks[track_index]
+            color_index = int(color_index)
+            color = int(color)
+            if color_index >= 0:
+                track.color_index = color_index
+            elif color >= 0:
+                track.color = color
+            else:
+                raise ValueError("Provide color_index (0-69) or color (RGB int).")
+            return {
+                "track_index": track_index,
+                "color_index": getattr(track, 'color_index', None),
+                "color": getattr(track, 'color', None),
+            }
+        except Exception as e:
+            self.log_message("Error setting track color: " + str(e))
+            raise
+
     def _get_browser_item(self, uri, path):
         """Get a browser item by URI or path"""
         try:

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -651,6 +651,88 @@ def load_drum_kit(ctx: Context, track_index: int, rack_uri: str, kit_path: str) 
         logger.error(f"Error loading drum kit: {str(e)}")
         return f"Error loading drum kit: {str(e)}"
 
+@mcp.tool()
+def create_return_track(ctx: Context) -> str:
+    """
+    Create a return track at the end of the session.
+
+    Returns the index of the newly created return track.
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("create_return_track", {})
+        return f"Created return track at index {result.get('return_track_index')} (total returns: {result.get('return_track_count')})"
+    except Exception as e:
+        logger.error(f"Error creating return track: {str(e)}")
+        return f"Error creating return track: {str(e)}"
+
+@mcp.tool()
+def duplicate_track(ctx: Context, track_index: int) -> str:
+    """
+    Duplicate a track (devices + clips). The new track appears at track_index + 1.
+
+    Parameters:
+    - track_index: The index of the track to duplicate
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("duplicate_track", {"track_index": track_index})
+        return f"Duplicated track {track_index} -> {result.get('new_track_index')} (total tracks: {result.get('track_count')})"
+    except Exception as e:
+        logger.error(f"Error duplicating track: {str(e)}")
+        return f"Error duplicating track: {str(e)}"
+
+@mcp.tool()
+def capture_midi(ctx: Context) -> str:
+    """
+    Trigger Live's MIDI Capture, which recovers MIDI played in the recent past
+    on the armed track.
+    """
+    try:
+        ableton = get_ableton_connection()
+        ableton.send_command("capture_midi", {})
+        return "Captured MIDI"
+    except Exception as e:
+        logger.error(f"Error capturing MIDI: {str(e)}")
+        return f"Error capturing MIDI: {str(e)}"
+
+@mcp.tool()
+def tap_tempo(ctx: Context) -> str:
+    """
+    Register a tap-tempo tap. Live gradually settles to the tap interval.
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("tap_tempo", {})
+        return f"Tap registered (current tempo: {result.get('tempo')})"
+    except Exception as e:
+        logger.error(f"Error tapping tempo: {str(e)}")
+        return f"Error tapping tempo: {str(e)}"
+
+@mcp.tool()
+def set_track_color(ctx: Context, track_index: int, color_index: int = -1, color: int = -1) -> str:
+    """
+    Set the color of a track.
+
+    Parameters:
+    - track_index: The index of the track
+    - color_index: Live's palette index (0-69). Preferred. Pass -1 to skip.
+    - color: Raw RGB integer (0xRRGGBB). Legacy fallback. Pass -1 to skip.
+
+    Provide either color_index or color (not both).
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("set_track_color", {
+            "track_index": track_index,
+            "color_index": color_index,
+            "color": color,
+        })
+        return f"Track {track_index} color set (color_index: {result.get('color_index')}, color: {result.get('color')})"
+    except Exception as e:
+        logger.error(f"Error setting track color: {str(e)}")
+        return f"Error setting track color: {str(e)}"
+
 # Main execution
 def main():
     """Run the MCP server"""


### PR DESCRIPTION
Five small additions to expose LOM methods that aren't currently surfaced. All strictly additive — no changes to existing handlers.

### Added commands

| Command | LOM method | Purpose |
|---|---|---|
| `create_return_track` | `Song.create_return_track()` | Create a return track at the end. Long-requested — see #26. |
| `duplicate_track` | `Song.duplicate_track(index)` | Duplicate a track (devices + clips). |
| `capture_midi` | `Song.capture_midi()` | Live's Capture MIDI — recovers MIDI played in the recent past on the armed track. |
| `tap_tempo` | `Song.tap_tempo()` | Register a tap-tempo tap. |
| `set_track_color` | `track.color_index` / `track.color` | Set a track's color by Live's palette index (0–69) or RGB integer. |

### Implementation

- Each handler is wired into the existing `main_thread_task` dispatch (state-changing, needs scheduled execution on Live's main thread).
- Method bodies follow the existing per-method pattern: validate input, call the LOM, return a small status dict, log on exception.
- Server-side `@mcp.tool()` wrappers mirror the existing style — one short function per command that calls `ableton.send_command`.

### Testing

Verified all five on Live 12 Suite (macOS):
- `create_return_track` adds a return at the end; `return_tracks_count` increments correctly.
- `duplicate_track` produces a copy at index+1 with devices and clips preserved.
- `capture_midi` recovers MIDI from the armed track's recent buffer.
- `tap_tempo` accepts a single tap (multiple taps settle to the tap interval).
- `set_track_color` accepts both the Live 10+ palette index (preferred) and the legacy RGB integer.

### Not included

`group_tracks` / `ungroup_track` — Live's Python LOM doesn't expose these even though `Song.group_tracks` exists as a Push-3 message internally. They're UI-only operations, so no wiring is possible from the Remote Script. Manual Cmd+G remains the only path for grouping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP tools to create a return track, duplicate a track, trigger Capture MIDI, register a tap-tempo tap, and set a track’s color (palette or RGB).
* **Bug Fixes**
  * Enhanced browser item discovery to include additional library locations, improving accessibility across plugins, Max for Live, user libraries, packs, and samples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ahujasid/ableton-mcp/pull/94)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->