### PR TITLE
[codex] Add Arrangement duplication commands

### DIFF
--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -229,7 +229,10 @@ class AbletonMCP(ControlSurface):
             elif command_type in ["create_midi_track", "set_track_name", 
                                  "create_clip", "add_notes_to_clip", "set_clip_name", 
                                  "set_tempo", "fire_clip", "stop_clip",
-                                 "start_playback", "stop_playback", "load_browser_item"]:
+                                 "start_playback", "stop_playback", "load_browser_item",
+                                 "duplicate_clip_to_arrangement",
+                                 "duplicate_scene_to_arrangement",
+                                 "back_to_arrangement", "stop_all_clips"]:
                 # Use a thread-safe approach with a response queue
                 response_queue = queue.Queue()
                 
@@ -270,6 +273,24 @@ class AbletonMCP(ControlSurface):
                             track_index = params.get("track_index", 0)
                             clip_index = params.get("clip_index", 0)
                             result = self._stop_clip(track_index, clip_index)
+                        elif command_type == "duplicate_clip_to_arrangement":
+                            track_index = params.get("track_index", 0)
+                            scene_index = params.get("scene_index", 0)
+                            start_time = params.get("start_time", 0.0)
+                            result = self._duplicate_clip_to_arrangement(
+                                track_index, scene_index, start_time
+                            )
+                        elif command_type == "duplicate_scene_to_arrangement":
+                            scene_index = params.get("scene_index", 0)
+                            start_time = params.get("start_time", 0.0)
+                            track_indices = params.get("track_indices", None)
+                            result = self._duplicate_scene_to_arrangement(
+                                scene_index, start_time, track_indices
+                            )
+                        elif command_type == "back_to_arrangement":
+                            result = self._back_to_arrangement()
+                        elif command_type == "stop_all_clips":
+                            result = self._stop_all_clips()
                         elif command_type == "start_playback":
                             result = self._start_playback()
                         elif command_type == "stop_playback":
@@ -609,6 +630,163 @@ class AbletonMCP(ControlSurface):
         except Exception as e:
             self.log_message("Error stopping clip: " + str(e))
             raise
+
+    def _duplicate_clip_to_arrangement(self, track_index, scene_index, start_time):
+        """Duplicate one Session clip into Arrangement."""
+        result = {
+            "success": False,
+            "scene_index": scene_index,
+            "start_time": start_time,
+            "duplicated": [],
+            "skipped": []
+        }
+        
+        try:
+            if track_index < 0 or track_index >= len(self._song.tracks):
+                raise IndexError("Track index out of range")
+            
+            track = self._song.tracks[track_index]
+            if scene_index < 0 or scene_index >= len(track.clip_slots):
+                raise IndexError("Scene index out of range")
+            
+            slot = track.clip_slots[scene_index]
+            if not slot.has_clip:
+                result["skipped"].append({
+                    "track_index": track_index,
+                    "track_name": track.name,
+                    "reason": "empty_slot"
+                })
+                result["success"] = True
+                return result
+            
+            if not hasattr(track, "duplicate_clip_to_arrangement"):
+                raise RuntimeError("Live API does not expose track.duplicate_clip_to_arrangement")
+            
+            clip = slot.clip
+            track.duplicate_clip_to_arrangement(clip, float(start_time))
+            result["duplicated"].append({
+                "track_index": track_index,
+                "track_name": track.name,
+                "clip_name": clip.name
+            })
+            result["success"] = True
+            return result
+        except Exception as e:
+            result["error"] = str(e)
+            self.log_message("Error duplicating clip to arrangement: " + str(e))
+            self.log_message(traceback.format_exc())
+            return result
+
+    def _duplicate_scene_to_arrangement(self, scene_index, start_time, track_indices=None):
+        """Duplicate all clips in a Session scene into Arrangement at start_time."""
+        result = {
+            "success": False,
+            "scene_index": scene_index,
+            "start_time": start_time,
+            "duplicated": [],
+            "skipped": []
+        }
+        
+        try:
+            tracks = self._song.tracks
+            
+            if track_indices is None:
+                selected_track_indices = range(len(tracks))
+            else:
+                if not isinstance(track_indices, list):
+                    raise TypeError("track_indices must be a list of zero-based track indices")
+                selected_track_indices = track_indices
+            
+            for track_index in selected_track_indices:
+                if track_index < 0 or track_index >= len(tracks):
+                    result["skipped"].append({
+                        "track_index": track_index,
+                        "track_name": "",
+                        "reason": "track_index_out_of_range"
+                    })
+                    continue
+                
+                track = tracks[track_index]
+                if scene_index < 0 or scene_index >= len(track.clip_slots):
+                    result["skipped"].append({
+                        "track_index": track_index,
+                        "track_name": track.name,
+                        "reason": "scene_index_out_of_range"
+                    })
+                    continue
+                
+                slot = track.clip_slots[scene_index]
+                if not slot.has_clip:
+                    result["skipped"].append({
+                        "track_index": track_index,
+                        "track_name": track.name,
+                        "reason": "empty_slot"
+                    })
+                    continue
+                
+                if not hasattr(track, "duplicate_clip_to_arrangement"):
+                    raise RuntimeError("Live API does not expose track.duplicate_clip_to_arrangement")
+                
+                clip = slot.clip
+                track.duplicate_clip_to_arrangement(clip, float(start_time))
+                result["duplicated"].append({
+                    "track_index": track_index,
+                    "track_name": track.name,
+                    "clip_name": clip.name
+                })
+            
+            result["success"] = True
+            return result
+        except Exception as e:
+            result["error"] = str(e)
+            self.log_message("Error duplicating scene to arrangement: " + str(e))
+            self.log_message(traceback.format_exc())
+            return result
+
+    def _back_to_arrangement(self):
+        """Re-enable Arrangement playback when Session clips have taken over."""
+        result = {
+            "success": False
+        }
+        
+        try:
+            if hasattr(self._song, "back_to_arranger"):
+                self._song.back_to_arranger = True
+            elif hasattr(self._song, "back_to_arrangement"):
+                attr = getattr(self._song, "back_to_arrangement")
+                if callable(attr):
+                    attr()
+                else:
+                    self._song.back_to_arrangement = True
+            else:
+                raise RuntimeError("Live API does not expose back_to_arranger/back_to_arrangement")
+            
+            result["success"] = True
+            return result
+        except Exception as e:
+            result["error"] = str(e)
+            self.log_message("Error returning to arrangement: " + str(e))
+            self.log_message(traceback.format_exc())
+            return result
+
+    def _stop_all_clips(self):
+        """Stop all Session clips."""
+        result = {
+            "success": False
+        }
+        
+        try:
+            if not hasattr(self._song, "stop_all_clips"):
+                raise RuntimeError("Live API does not expose stop_all_clips")
+            
+            self._song.stop_all_clips()
+            result["success"] = True
+            return result
+        except Exception as e:
+            result["error"] = str(e)
+            self.log_message("Error stopping all clips: " + str(e))
+            self.log_message(traceback.format_exc())
+            return result
     
     
     def _start_playback(self):

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -105,7 +105,9 @@ class AbletonConnection:
             "create_midi_track", "create_audio_track", "set_track_name",
             "create_clip", "add_notes_to_clip", "set_clip_name",
             "set_tempo", "fire_clip", "stop_clip", "set_device_parameter",
-            "start_playback", "stop_playback", "load_instrument_or_effect"
+            "start_playback", "stop_playback", "load_instrument_or_effect",
+            "duplicate_clip_to_arrangement", "duplicate_scene_to_arrangement",
+            "back_to_arrangement", "stop_all_clips"
         ]
         
         try:
@@ -475,6 +477,85 @@ def stop_clip(ctx: Context, track_index: int, clip_index: int) -> str:
     except Exception as e:
         logger.error(f"Error stopping clip: {str(e)}")
         return f"Error stopping clip: {str(e)}"
+
+@mcp.tool()
+def duplicate_clip_to_arrangement(
+    ctx: Context,
+    track_index: int,
+    scene_index: int,
+    start_time: float
+) -> str:
+    """
+    Duplicate one Session clip into Arrangement.
+    
+    Parameters:
+    - track_index: Zero-based track index
+    - scene_index: Zero-based Session scene/clip-slot index
+    - start_time: Arrangement destination time in beats, where 0 = bar 1 beat 1
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("duplicate_clip_to_arrangement", {
+            "track_index": track_index,
+            "scene_index": scene_index,
+            "start_time": start_time
+        })
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        logger.error(f"Error duplicating clip to Arrangement: {str(e)}")
+        return f"Error duplicating clip to Arrangement: {str(e)}"
+
+@mcp.tool()
+def duplicate_scene_to_arrangement(
+    ctx: Context,
+    scene_index: int,
+    start_time: float,
+    track_indices: List[int] = None
+) -> str:
+    """
+    Duplicate all clips from a Session scene into Arrangement.
+    
+    Parameters:
+    - scene_index: Zero-based Session scene/clip-slot index
+    - start_time: Arrangement destination time in beats, where 0 = bar 1 beat 1
+    - track_indices: Optional list of zero-based track indices. If omitted, all normal tracks are processed.
+    """
+    try:
+        params = {
+            "scene_index": scene_index,
+            "start_time": start_time
+        }
+        if track_indices is not None:
+            params["track_indices"] = track_indices
+        
+        ableton = get_ableton_connection()
+        result = ableton.send_command("duplicate_scene_to_arrangement", params)
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        logger.error(f"Error duplicating scene to Arrangement: {str(e)}")
+        return f"Error duplicating scene to Arrangement: {str(e)}"
+
+@mcp.tool()
+def back_to_arrangement(ctx: Context) -> str:
+    """Re-enable Arrangement playback after Session clips have taken over."""
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("back_to_arrangement")
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        logger.error(f"Error returning to Arrangement: {str(e)}")
+        return f"Error returning to Arrangement: {str(e)}"
+
+@mcp.tool()
+def stop_all_clips(ctx: Context) -> str:
+    """Stop all Session clips."""
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("stop_all_clips")
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        logger.error(f"Error stopping all clips: {str(e)}")
+        return f"Error stopping all clips: {str(e)}"
 
 @mcp.tool()
 def start_playback(ctx: Context) -> str:


### PR DESCRIPTION
## Summary
- Add Remote Script socket commands for duplicating Session clips into Arrangement.
- Expose matching MCP tools for single-clip and full-scene duplication.
- Add helper commands to stop stale Session clips and return playback to Arrangement.

## Why
AbletonMCP could create and launch Session clips reliably, but getting those clips into Arrangement required slow real-time Arrangement Record. This adds an instant API path using Live's `track.duplicate_clip_to_arrangement(clip, start_time)` so clients can build in Session View and then render/export real Arrangement audio.

## Validation
- Ran `python3 -m py_compile AbletonMCP_Remote_Script/__init__.py MCP_Server/server.py`.
- Installed the Remote Script from a user-level symlink into a local editable checkout.
- Restarted Ableton Live and verified direct socket calls:
  - `stop_all_clips` returns `success: true`.
  - `back_to_arrangement` returns `success: true`.
  - `duplicate_scene_to_arrangement` skips empty slots with structured reasons.
  - Created a test MIDI clip and confirmed both `duplicate_clip_to_arrangement` and `duplicate_scene_to_arrangement` report the clip duplicated into Arrangement.

## Notes
The final audio export acceptance test was not run because the quick test MIDI clip had no instrument loaded; this PR verifies the Arrangement duplication API path itself.
