### PR TITLE
Add create_audio_clip: import an audio file into an audio-track clip slot

### DIFF
--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -226,8 +226,8 @@ class AbletonMCP(ControlSurface):
                 track_index = params.get("track_index", 0)
                 response["result"] = self._get_track_info(track_index)
             # Commands that modify Live's state should be scheduled on the main thread
-            elif command_type in ["create_midi_track", "set_track_name", 
-                                 "create_clip", "add_notes_to_clip", "set_clip_name", 
+            elif command_type in ["create_midi_track", "set_track_name",
+                                 "create_clip", "create_audio_clip", "add_notes_to_clip", "set_clip_name",
                                  "set_tempo", "fire_clip", "stop_clip",
                                  "start_playback", "stop_playback", "load_browser_item"]:
                 # Use a thread-safe approach with a response queue
@@ -249,6 +249,11 @@ class AbletonMCP(ControlSurface):
                             clip_index = params.get("clip_index", 0)
                             length = params.get("length", 4.0)
                             result = self._create_clip(track_index, clip_index, length)
+                        elif command_type == "create_audio_clip":
+                            track_index = params.get("track_index", 0)
+                            clip_index = params.get("clip_index", 0)
+                            path = params.get("path", "")
+                            result = self._create_audio_clip(track_index, clip_index, path)
                         elif command_type == "add_notes_to_clip":
                             track_index = params.get("track_index", 0)
                             clip_index = params.get("clip_index", 0)
@@ -480,7 +485,38 @@ class AbletonMCP(ControlSurface):
         except Exception as e:
             self.log_message("Error creating clip: " + str(e))
             raise
-    
+
+    def _create_audio_clip(self, track_index, clip_index, path):
+        """Create an audio clip in the specified audio track clip slot by importing a file."""
+        try:
+            if not path:
+                raise ValueError("Audio file path is required")
+
+            if track_index < 0 or track_index >= len(self._song.tracks):
+                raise IndexError("Track index out of range")
+
+            track = self._song.tracks[track_index]
+
+            if clip_index < 0 or clip_index >= len(track.clip_slots):
+                raise IndexError("Clip index out of range")
+
+            clip_slot = track.clip_slots[clip_index]
+
+            if clip_slot.has_clip:
+                raise Exception("Clip slot already has a clip")
+
+            clip_slot.create_audio_clip(path)
+
+            result = {
+                "name": clip_slot.clip.name,
+                "length": clip_slot.clip.length,
+                "is_audio_clip": clip_slot.clip.is_audio_clip
+            }
+            return result
+        except Exception as e:
+            self.log_message("Error creating audio clip: " + str(e))
+            raise
+
     def _add_notes_to_clip(self, track_index, clip_index, notes):
         """Add MIDI notes to a clip"""
         try:

--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 from _Framework.ControlSurface import ControlSurface
+import os
 import socket
 import json
 import threading
@@ -302,9 +303,14 @@ class AbletonMCP(ControlSurface):
                     # If we're already on the main thread, execute directly
                     main_thread_task()
                 
-                # Wait for the response with a timeout
+                # Wait for the response with a timeout. Some commands (notably
+                # create_audio_clip, which decodes/imports the audio file on
+                # the main thread) can take longer than the default 10s on
+                # larger files — give them more headroom.
+                long_running_commands = {"create_audio_clip": 60.0}
+                queue_timeout = long_running_commands.get(command_type, 10.0)
                 try:
-                    task_response = response_queue.get(timeout=10.0)
+                    task_response = response_queue.get(timeout=queue_timeout)
                     if task_response.get("status") == "error":
                         response["status"] = "error"
                         response["message"] = task_response.get("message", "Unknown error")
@@ -487,15 +493,29 @@ class AbletonMCP(ControlSurface):
             raise
 
     def _create_audio_clip(self, track_index, clip_index, path):
-        """Create an audio clip in the specified audio track clip slot by importing a file."""
+        """Create an audio clip in the specified audio track clip slot by importing a file.
+
+        Requires Ableton Live 12.0.5 or newer (the underlying
+        ClipSlot.create_audio_clip Live API was introduced in 12.0.5 — it is
+        not available in earlier 12.0.x releases).
+        """
         try:
             if not path:
                 raise ValueError("Audio file path is required")
+
+            if not os.path.isabs(path):
+                raise ValueError("Audio file path must be absolute (got: %s)" % path)
 
             if track_index < 0 or track_index >= len(self._song.tracks):
                 raise IndexError("Track index out of range")
 
             track = self._song.tracks[track_index]
+
+            # Must be an audio track. Audio tracks expose audio input; MIDI
+            # tracks don't. Reject MIDI / return tracks up front so the caller
+            # gets a clear error instead of a Live API exception.
+            if getattr(track, "has_midi_input", False) or not getattr(track, "has_audio_input", True):
+                raise ValueError("Track %d is not an audio track" % track_index)
 
             if clip_index < 0 or clip_index >= len(track.clip_slots):
                 raise IndexError("Clip index out of range")
@@ -504,6 +524,12 @@ class AbletonMCP(ControlSurface):
 
             if clip_slot.has_clip:
                 raise Exception("Clip slot already has a clip")
+
+            if not hasattr(clip_slot, "create_audio_clip"):
+                raise Exception(
+                    "ClipSlot.create_audio_clip is unavailable in this Ableton Live "
+                    "version. Requires Live 12.0.5 or newer."
+                )
 
             clip_slot.create_audio_clip(path)
 

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -341,6 +341,29 @@ def create_clip(ctx: Context, track_index: int, clip_index: int, length: float =
         return f"Error creating clip: {str(e)}"
 
 @mcp.tool()
+def create_audio_clip(ctx: Context, track_index: int, clip_index: int, path: str) -> str:
+    """
+    Create a new audio clip in an audio track's clip slot by importing a file.
+
+    Parameters:
+    - track_index: The index of the audio track to create the clip in
+    - clip_index: The index of the clip slot to create the clip in
+    - path: Absolute path to a supported audio file (e.g. a .wav). The target
+      track must be an audio track and the clip slot must be empty.
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("create_audio_clip", {
+            "track_index": track_index,
+            "clip_index": clip_index,
+            "path": path
+        })
+        return f"Created audio clip '{result.get('name', 'clip')}' at track {track_index}, slot {clip_index} (length {result.get('length', '?')} beats)"
+    except Exception as e:
+        logger.error(f"Error creating audio clip: {str(e)}")
+        return f"Error creating audio clip: {str(e)}"
+
+@mcp.tool()
 def add_notes_to_clip(
     ctx: Context, 
     track_index: int, 

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -103,10 +103,16 @@ class AbletonConnection:
         # Check if this is a state-modifying command
         is_modifying_command = command_type in [
             "create_midi_track", "create_audio_track", "set_track_name",
-            "create_clip", "add_notes_to_clip", "set_clip_name",
+            "create_clip", "create_audio_clip", "add_notes_to_clip", "set_clip_name",
             "set_tempo", "fire_clip", "stop_clip", "set_device_parameter",
             "start_playback", "stop_playback", "load_instrument_or_effect"
         ]
+
+        # Commands whose work on Live's main thread can take noticeably longer
+        # than the default modifying-command budget (e.g. importing/decoding a
+        # large audio file). Give them a wider socket timeout so we don't time
+        # out before the Remote Script's own queue does.
+        long_running_commands = {"create_audio_clip": 65.0}
         
         try:
             logger.info(f"Sending command: {command_type} with params: {params}")
@@ -121,7 +127,10 @@ class AbletonConnection:
                 time.sleep(0.1)  # 100ms delay
             
             # Set timeout based on command type
-            timeout = 15.0 if is_modifying_command else 10.0
+            if command_type in long_running_commands:
+                timeout = long_running_commands[command_type]
+            else:
+                timeout = 15.0 if is_modifying_command else 10.0
             self.sock.settimeout(timeout)
             
             # Receive the response
@@ -344,6 +353,10 @@ def create_clip(ctx: Context, track_index: int, clip_index: int, length: float =
 def create_audio_clip(ctx: Context, track_index: int, clip_index: int, path: str) -> str:
     """
     Create a new audio clip in an audio track's clip slot by importing a file.
+
+    Requires Ableton Live 12.0.5 or newer — the underlying
+    ClipSlot.create_audio_clip Live API was introduced in 12.0.5 and is not
+    available in earlier 12.0.x releases.
 
     Parameters:
     - track_index: The index of the audio track to create the clip in


### PR DESCRIPTION
## What

Adds a `create_audio_clip` MCP tool (plus the matching Remote Script handler) that imports a local audio file into an **empty clip slot on an audio track**, via the Live API's `ClipSlot.create_audio_clip(path)`.

```
create_audio_clip(track_index, clip_index, path)
```

## Why

There's currently no way through the MCP to get a file-based audio clip into Live — you can create MIDI clips and add notes, but not drop a rendered/exported WAV into a clip slot. This unlocks file-based audio handoff (e.g. generate/render audio elsewhere → import it straight into a Live clip → fire/process it).

## How

- **Remote Script** (`AbletonMCP_Remote_Script/__init__.py`): `_create_audio_clip` handler + command dispatch + entry in the main-thread modifying-command list. Validates the track/slot indices and that the slot is empty; returns `{name, length, is_audio_clip}`.
- **MCP server** (`MCP_Server/server.py`): `create_audio_clip(track_index, clip_index, path)` tool, same style/error-handling as `create_clip`.

## Notes / constraints

- `path` must be an absolute path to a supported audio file, local to the machine running Live.
- Target must be an **audio** track and the clip slot must be **empty**.

## Tested

Verified live on **Ableton Live 12 Intro**: a 2.0s WAV imported into an audio track, response `{"name": "...", "length": 2.0, "is_audio_clip": true}`, and a follow-up session read confirmed the slot now holds a non-MIDI clip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import and create audio clips directly into specified tracks and clip slots, returning clip name and length on success.

* **Improvements**
  * Longer timeout for audio-import operations to accommodate slower processing.
  * Improved success and error responses when creating audio clips.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ahujasid/ableton-mcp/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->