### PR TITLE
Add start-at-beat playback and arrangement loop controls

### DIFF
--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -233,6 +233,7 @@ class AbletonMCP(ControlSurface):
                                  "start_playback", "stop_playback", "load_browser_item",
                                  # Arrangement view – must run on the main thread
                                  "switch_to_arrangement_view", "set_current_song_time",
+                                 "set_arrangement_loop", "set_arrangement_loop_enabled",
                                  "duplicate_session_clip_to_arrangement"]:
                 # Use a thread-safe approach with a response queue
                 response_queue = queue.Queue()
@@ -280,7 +281,8 @@ class AbletonMCP(ControlSurface):
                             clip_index = params.get("clip_index", 0)
                             result = self._stop_clip(track_index, clip_index)
                         elif command_type == "start_playback":
-                            result = self._start_playback()
+                            start_time = params.get("start_time", None)
+                            result = self._start_playback(start_time)
                         elif command_type == "stop_playback":
                             result = self._stop_playback()
                         elif command_type == "load_instrument_or_effect":
@@ -297,6 +299,14 @@ class AbletonMCP(ControlSurface):
                         elif command_type == "set_current_song_time":
                             time_val = params.get("time", 0.0)
                             result = self._set_current_song_time(time_val)
+                        elif command_type == "set_arrangement_loop":
+                            loop_start = params.get("loop_start", 0.0)
+                            loop_length = params.get("loop_length", 4.0)
+                            enabled = params.get("enabled", True)
+                            result = self._set_arrangement_loop(loop_start, loop_length, enabled)
+                        elif command_type == "set_arrangement_loop_enabled":
+                            enabled = params.get("enabled", True)
+                            result = self._set_arrangement_loop_enabled(enabled)
                         elif command_type == "duplicate_session_clip_to_arrangement":
                             track_index = params.get("track_index", 0)
                             clip_index = params.get("clip_index", 0)
@@ -368,6 +378,26 @@ class AbletonMCP(ControlSurface):
         return response
     
     # Command implementations
+
+    def _validate_non_negative_beat(self, value, parameter_name):
+        """Validate a beat position counted from the start of the arrangement."""
+        beat_value = float(value)
+        if beat_value < 0.0:
+            raise ValueError(parameter_name + " must be greater than or equal to 0")
+        return beat_value
+
+    def _validate_positive_beat_length(self, value, parameter_name):
+        """Validate a beat length such as an arrangement loop span."""
+        beat_length = float(value)
+        if beat_length <= 0.0:
+            raise ValueError(parameter_name + " must be greater than 0")
+        return beat_length
+
+    def _validate_bool(self, value, parameter_name):
+        """Validate boolean values sent over the raw socket protocol."""
+        if not isinstance(value, bool):
+            raise ValueError(parameter_name + " must be a boolean")
+        return value
     
     def _safe_song_property(self, attr, cast, default):
         """Read self._song.<attr> with cast, returning default on common failures.
@@ -711,13 +741,17 @@ class AbletonMCP(ControlSurface):
             raise
     
     
-    def _start_playback(self):
+    def _start_playback(self, start_time=None):
         """Start playing the session"""
         try:
+            if start_time is not None:
+                self._set_current_song_time(start_time)
+
             self._song.start_playing()
             
             result = {
-                "playing": self._song.is_playing
+                "playing": self._song.is_playing,
+                "current_song_time": self._song.current_song_time
             }
             return result
         except Exception as e:
@@ -751,10 +785,43 @@ class AbletonMCP(ControlSurface):
     def _set_current_song_time(self, time_val):
         """Move the arrangement playhead to a position in beats"""
         try:
-            self._song.current_song_time = float(time_val)
+            self._song.current_song_time = self._validate_non_negative_beat(time_val, "time")
             return {"current_song_time": self._song.current_song_time}
         except Exception as e:
             self.log_message("Error setting current song time: " + str(e))
+            raise
+
+    def _set_arrangement_loop(self, loop_start, loop_length, enabled):
+        """Set Ableton's Arrangement loop brace and enabled state"""
+        try:
+            loop_start = self._validate_non_negative_beat(loop_start, "loop_start")
+            loop_length = self._validate_positive_beat_length(loop_length, "loop_length")
+            enabled = self._validate_bool(enabled, "enabled")
+
+            self._song.loop_start = loop_start
+            self._song.loop_length = loop_length
+            self._song.loop = enabled
+            return {
+                "loop": self._song.loop,
+                "loop_start": self._song.loop_start,
+                "loop_length": self._song.loop_length
+            }
+        except Exception as e:
+            self.log_message("Error setting arrangement loop: " + str(e))
+            raise
+
+    def _set_arrangement_loop_enabled(self, enabled):
+        """Enable or disable Ableton's Arrangement loop"""
+        try:
+            enabled = self._validate_bool(enabled, "enabled")
+            self._song.loop = enabled
+            return {
+                "loop": self._song.loop,
+                "loop_start": self._song.loop_start,
+                "loop_length": self._song.loop_length
+            }
+        except Exception as e:
+            self.log_message("Error setting arrangement loop enabled state: " + str(e))
             raise
 
     def _get_arrangement_clips(self, track_index):

--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -5,6 +5,7 @@ from _Framework.ControlSurface import ControlSurface
 import os
 import socket
 import json
+import math
 import threading
 import time
 import traceback
@@ -382,6 +383,8 @@ class AbletonMCP(ControlSurface):
     def _validate_non_negative_beat(self, value, parameter_name):
         """Validate a beat position counted from the start of the arrangement."""
         beat_value = float(value)
+        if math.isnan(beat_value) or math.isinf(beat_value):
+            raise ValueError(parameter_name + " must be finite")
         if beat_value < 0.0:
             raise ValueError(parameter_name + " must be greater than or equal to 0")
         return beat_value
@@ -389,6 +392,8 @@ class AbletonMCP(ControlSurface):
     def _validate_positive_beat_length(self, value, parameter_name):
         """Validate a beat length such as an arrangement loop span."""
         beat_length = float(value)
+        if math.isnan(beat_length) or math.isinf(beat_length):
+            raise ValueError(parameter_name + " must be finite")
         if beat_length <= 0.0:
             raise ValueError(parameter_name + " must be greater than 0")
         return beat_length

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -3,6 +3,7 @@ from mcp.server.fastmcp import FastMCP, Context
 import socket
 import json
 import logging
+import math
 import os
 from dataclasses import dataclass
 from contextlib import asynccontextmanager
@@ -23,6 +24,8 @@ logger = logging.getLogger("AbletonMCPServer")
 def validate_non_negative_beat(value: float, parameter_name: str) -> float:
     """Validate a beat position counted from the start of the arrangement."""
     beat_value = float(value)
+    if not math.isfinite(beat_value):
+        raise ValueError(f"{parameter_name} must be finite")
     if beat_value < 0.0:
         raise ValueError(f"{parameter_name} must be greater than or equal to 0")
     return beat_value
@@ -31,6 +34,8 @@ def validate_non_negative_beat(value: float, parameter_name: str) -> float:
 def validate_positive_beat_length(value: float, parameter_name: str) -> float:
     """Validate a beat length such as an arrangement loop span."""
     beat_length = float(value)
+    if not math.isfinite(beat_length):
+        raise ValueError(f"{parameter_name} must be finite")
     if beat_length <= 0.0:
         raise ValueError(f"{parameter_name} must be greater than 0")
     return beat_length

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -19,6 +19,23 @@ logging.basicConfig(level=logging.INFO,
                     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger("AbletonMCPServer")
 
+
+def validate_non_negative_beat(value: float, parameter_name: str) -> float:
+    """Validate a beat position counted from the start of the arrangement."""
+    beat_value = float(value)
+    if beat_value < 0.0:
+        raise ValueError(f"{parameter_name} must be greater than or equal to 0")
+    return beat_value
+
+
+def validate_positive_beat_length(value: float, parameter_name: str) -> float:
+    """Validate a beat length such as an arrangement loop span."""
+    beat_length = float(value)
+    if beat_length <= 0.0:
+        raise ValueError(f"{parameter_name} must be greater than 0")
+    return beat_length
+
+
 @dataclass
 class AbletonConnection:
     host: str
@@ -117,6 +134,7 @@ class AbletonConnection:
             "start_playback", "stop_playback", "load_instrument_or_effect",
             # Arrangement view commands
             "switch_to_arrangement_view", "set_current_song_time",
+            "set_arrangement_loop", "set_arrangement_loop_enabled",
             "duplicate_session_clip_to_arrangement"
         ]
 
@@ -543,16 +561,23 @@ def stop_clip(ctx: Context, track_index: int, clip_index: int, user_prompt: str 
         return f"Error stopping clip: {str(e)}"
 
 @mcp.tool()
-@telemetry_tool("start_playback")
-def start_playback(ctx: Context, user_prompt: str = "") -> str:
+@rich_telemetry_tool("start_playback")
+def start_playback(ctx: Context, start_time: float | None = None, user_prompt: str = "") -> str:
     """Start playing the Ableton session.
 
     Parameters:
+    - start_time: Optional beat position to move the arrangement playhead to before playback starts
     - user_prompt: The original user prompt that led to this tool call (for telemetry)
     """
     try:
         ableton = get_ableton_connection()
-        result = ableton.send_command("start_playback")
+        params = {}
+        if start_time is not None:
+            params["start_time"] = validate_non_negative_beat(start_time, "start_time")
+
+        result = ableton.send_command("start_playback", params)
+        if start_time is not None and "current_song_time" in result:
+            return f"Started playback at beat {result.get('current_song_time')}"
         return "Started playback"
     except Exception as e:
         logger.error(f"Error starting playback: {str(e)}")
@@ -763,12 +788,70 @@ def set_arrangement_time(ctx: Context, time: float, user_prompt: str = "") -> st
     - user_prompt: The original user prompt that led to this tool call (for telemetry)
     """
     try:
+        time = validate_non_negative_beat(time, "time")
         ableton = get_ableton_connection()
         result = ableton.send_command("set_current_song_time", {"time": time})
         return f"Playhead moved to beat {result.get('current_song_time', time)}"
     except Exception as e:
         logger.error(f"Error setting arrangement time: {str(e)}")
         return f"Error setting arrangement time: {str(e)}"
+
+
+@mcp.tool()
+@rich_telemetry_tool("set_arrangement_loop")
+def set_arrangement_loop(
+    ctx: Context,
+    loop_start: float,
+    loop_length: float,
+    enabled: bool = True,
+    user_prompt: str = "",
+) -> str:
+    """
+    Set the Arrangement loop brace and optionally enable looping.
+
+    Parameters:
+    - loop_start: Beat position where the loop starts
+    - loop_length: Loop duration in beats
+    - enabled: Whether arrangement looping should be enabled after setting the range
+    - user_prompt: The original user prompt that led to this tool call (for telemetry)
+    """
+    try:
+        loop_start = validate_non_negative_beat(loop_start, "loop_start")
+        loop_length = validate_positive_beat_length(loop_length, "loop_length")
+        ableton = get_ableton_connection()
+        result = ableton.send_command("set_arrangement_loop", {
+            "loop_start": loop_start,
+            "loop_length": loop_length,
+            "enabled": enabled,
+        })
+        loop_state = "enabled" if result.get("loop", enabled) else "disabled"
+        return (
+            f"Arrangement loop {loop_state}: beat {result.get('loop_start', loop_start)} "
+            f"for {result.get('loop_length', loop_length)} beats"
+        )
+    except Exception as e:
+        logger.error(f"Error setting arrangement loop: {str(e)}")
+        return f"Error setting arrangement loop: {str(e)}"
+
+
+@mcp.tool()
+@rich_telemetry_tool("set_arrangement_loop_enabled")
+def set_arrangement_loop_enabled(ctx: Context, enabled: bool, user_prompt: str = "") -> str:
+    """
+    Enable or disable Arrangement looping without changing the loop brace.
+
+    Parameters:
+    - enabled: Whether arrangement looping should be enabled
+    - user_prompt: The original user prompt that led to this tool call (for telemetry)
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("set_arrangement_loop_enabled", {"enabled": enabled})
+        loop_state = "enabled" if result.get("loop", enabled) else "disabled"
+        return f"Arrangement loop {loop_state}"
+    except Exception as e:
+        logger.error(f"Error setting arrangement loop enabled state: {str(e)}")
+        return f"Error setting arrangement loop enabled state: {str(e)}"
 
 
 @mcp.tool()

--- a/MCP_Server/telemetry_decorator.py
+++ b/MCP_Server/telemetry_decorator.py
@@ -37,7 +37,9 @@ def _extract_tool_params(kwargs: dict, capture_notes: bool = False) -> dict:
         # Track/clip identifiers (not sensitive, just indices)
         'track_index', 'clip_index', 'index',
         # Timing params
-        'length', 'time', 'destination_time', 'tempo',
+        'length', 'time', 'start_time', 'destination_time', 'loop_start', 'loop_length', 'tempo',
+        # Boolean transport params
+        'enabled',
         # Browser/instrument params (with consent - can reveal user's sound choices)
         'uri', 'rack_uri', 'kit_path', 'category_type',
         # Names (with consent - user-created content)

--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ Once the config file has been set on Claude, and the remote script is running in
 - Load instruments and effects from Ableton's browser
 - Add notes to MIDI clips
 - Change tempo and other session parameters
+- Start playback from a specific beat and configure Arrangement loop playback
+
+### Transport Examples
+
+| What you can ask | Tool behavior |
+| --- | --- |
+| "Start playback at beat 256" | Moves the Arrangement playhead to beat 256 and starts playback |
+| "Loop 16 beats starting at beat 256" | Sets the Arrangement loop brace to start at beat 256 for 16 beats and enables looping |
+| "Turn arrangement loop off" | Disables Arrangement looping without moving the existing loop brace |
 
 ## Example Commands
 
@@ -149,6 +158,9 @@ Here are some examples of what you can ask Claude to do:
 - "Add a jazz chord progression to the clip in track 1"
 - "Set the tempo to 120 BPM"
 - "Play the clip in track 2"
+- "Start playback at beat 256"
+- "Loop 16 beats starting at beat 256"
+- "Turn arrangement loop off"
 
 
 ## Troubleshooting


### PR DESCRIPTION
## What
Adds three additive transport controls for arrangement playback workflows:

- `start_playback(start_time?)` can optionally start playback from a specific arrangement beat.
- `set_arrangement_loop(loop_start, loop_length, enabled=true)` writes the arrangement loop region.
- `set_arrangement_loop_enabled(enabled)` toggles the existing loop region without moving it.

## Why
AbletonMCP can already start/stop playback and set the arrangement playhead, and `get_session_info` already reports `loop`, `loop_start`, and `loop_length`. Clients still need multiple commands to start from a known beat and cannot write loop state.

This fills that gap for repeated listening, profiling, render comparison, and generation checks where an agent needs to jump to the same section, start playback, and optionally loop it.

## Current transport surface

| Need | Existing support | Gap |
| --- | --- | --- |
| Start playback | `start_playback()` | No one-command start-at-beat |
| Stop playback | `stop_playback()` | Covered |
| Move arrangement playhead | `set_arrangement_time(time)` | Requires a second command before playback |
| Read playback state | `get_session_info()` | Covered |
| Read arrangement loop state | `get_session_info()` | Covered |
| Set arrangement loop state | None | Cannot create/update a loop region |
| Toggle arrangement loop | None | Cannot enable/disable loop playback |

## Added commands

| Tool | Parameters | Behavior |
| --- | --- | --- |
| `start_playback` | `start_time?: number` | Preserves existing behavior when omitted; when provided, validates the beat, sets `Song.current_song_time`, then calls `Song.start_playing()` |
| `set_arrangement_loop` | `loop_start: number`, `loop_length: number`, `enabled: boolean = true` | Validates finite beat values, writes `Song.loop_start`, `Song.loop_length`, and `Song.loop` |
| `set_arrangement_loop_enabled` | `enabled: boolean` | Validates the raw socket value is boolean and writes `Song.loop` |

## How
- Remote Script routes the new state-changing commands through the existing main-thread scheduling path.
- MCP server exposes the new tools and keeps `start_playback()` backward compatible.
- Beat inputs reject negative, zero-length, `NaN`, and infinite values before reaching Live.
- README examples document common transport prompts.
- Telemetry capture includes the new transport parameters.

## Notes / constraints
- This is purely additive: existing `start_playback()` calls still work and still return `Started playback`.
- Beat units follow the existing `set_arrangement_time(time)` arrangement-beat convention.
- App quit/restart/plugin rescan controls are intentionally not included here. Those are broader OS/application lifecycle workflows rather than stable Ableton Live Remote Script commands.

## Validation
- `uv run python -m compileall MCP_Server AbletonMCP_Remote_Script`
- FastMCP schema inspection confirmed the new optional/required tool arguments.
- Fake Ableton connection smoke test covered:
  - `start_playback()`
  - `start_playback(start_time=256.0)`
  - `set_arrangement_loop(loop_start=256.0, loop_length=16.0)`
  - `set_arrangement_loop_enabled(enabled=false)`
  - invalid negative and infinite beat values
- Offline Remote Script smoke test with a fake `Song` covered:
  - `_start_playback(256.0)`
  - `_set_arrangement_loop(256.0, 16.0, True)`
  - `_set_arrangement_loop_enabled(False)`
  - `NaN`, infinite length, and non-boolean error cases
- `git diff --check`
