### PR TITLE
Add get_notes_from_clip and clear_notes_from_clip MIDI tools

### DIFF
--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -229,6 +229,7 @@ class AbletonMCP(ControlSurface):
             # Commands that modify Live's state should be scheduled on the main thread
             elif command_type in ["create_midi_track", "set_track_name",
                                  "create_clip", "create_audio_clip", "add_notes_to_clip", "set_clip_name",
+                                 "clear_notes_from_clip",
                                  "set_tempo", "fire_clip", "stop_clip",
                                  "start_playback", "stop_playback", "load_browser_item",
                                  # Arrangement view – must run on the main thread
@@ -263,6 +264,10 @@ class AbletonMCP(ControlSurface):
                             clip_index = params.get("clip_index", 0)
                             notes = params.get("notes", [])
                             result = self._add_notes_to_clip(track_index, clip_index, notes)
+                        elif command_type == "clear_notes_from_clip":
+                            track_index = params.get("track_index", 0)
+                            clip_index = params.get("clip_index", 0)
+                            result = self._clear_notes_from_clip(track_index, clip_index)
                         elif command_type == "set_clip_name":
                             track_index = params.get("track_index", 0)
                             clip_index = params.get("clip_index", 0)
@@ -356,6 +361,12 @@ class AbletonMCP(ControlSurface):
             elif command_type == "get_arrangement_clips":
                 track_index = params.get("track_index", 0)
                 response["result"] = self._get_arrangement_clips(track_index)
+            # Read-only clip command – no main-thread scheduling required
+            # (mirrors the get_arrangement_clips precedent above)
+            elif command_type == "get_notes_from_clip":
+                track_index = params.get("track_index", 0)
+                clip_index = params.get("clip_index", 0)
+                response["result"] = self._get_notes_from_clip(track_index, clip_index)
             else:
                 response["status"] = "error"
                 response["message"] = "Unknown command: " + command_type
@@ -792,6 +803,142 @@ class AbletonMCP(ControlSurface):
             }
         except Exception as e:
             self.log_message("Error getting arrangement clips: " + str(e))
+            raise
+
+    def _get_notes_from_clip(self, track_index, clip_index):
+        """Read all MIDI notes from a Session clip.
+
+        Returns notes in the same shape add_notes_to_clip consumes
+        (pitch, start_time, duration, velocity, mute) so the result can be
+        edited and written straight back — a true read -> modify -> write
+        loop. Where Live exposes them, richer per-note fields (note_id,
+        probability, velocity_deviation, release_velocity) are included too.
+        """
+        try:
+            if track_index < 0 or track_index >= len(self._song.tracks):
+                raise IndexError("Track index out of range")
+
+            track = self._song.tracks[track_index]
+
+            if clip_index < 0 or clip_index >= len(track.clip_slots):
+                raise IndexError("Clip index out of range")
+
+            clip_slot = track.clip_slots[clip_index]
+
+            if not clip_slot.has_clip:
+                raise Exception("No clip in slot")
+
+            clip = clip_slot.clip
+
+            if not clip.is_midi_clip:
+                raise Exception("Clip is not a MIDI clip; no notes to read")
+
+            length = clip.length
+            notes = []
+
+            # Prefer the modern, note-id-aware API (Live 11+). Signature is
+            # get_notes_extended(from_pitch, pitch_span, from_time, time_span);
+            # note the pitch-FIRST argument order, which differs from the
+            # legacy get_notes(from_time, from_pitch, time_span, pitch_span).
+            extended = getattr(clip, "get_notes_extended", None)
+            if extended is not None:
+                note_vector = extended(0, 128, 0.0, length)
+                for n in note_vector:
+                    note = {
+                        "pitch": n.pitch,
+                        "start_time": n.start_time,
+                        "duration": n.duration,
+                        "velocity": n.velocity,
+                        "mute": n.mute,
+                    }
+                    for extra in ("note_id", "probability",
+                                  "velocity_deviation", "release_velocity"):
+                        if hasattr(n, extra):
+                            note[extra] = getattr(n, extra)
+                    notes.append(note)
+            else:
+                # Legacy fallback: returns tuples of
+                # (pitch, start_time, duration, velocity, mute).
+                raw = clip.get_notes(0.0, 0, length, 128)
+                for pitch, start_time, duration, velocity, mute in raw:
+                    notes.append({
+                        "pitch": pitch,
+                        "start_time": start_time,
+                        "duration": duration,
+                        "velocity": velocity,
+                        "mute": mute,
+                    })
+
+            return {
+                "track_index": track_index,
+                "clip_index": clip_index,
+                "clip_name": clip.name,
+                "length": length,
+                "note_count": len(notes),
+                "notes": notes,
+            }
+        except Exception as e:
+            self.log_message("Error getting notes from clip: " + str(e))
+            raise
+
+    def _clear_notes_from_clip(self, track_index, clip_index):
+        """Remove all MIDI notes from a Session clip.
+
+        Pairs with _add_notes_to_clip to make a real replace (clear, then add),
+        which the write-only API otherwise can't do. Counts notes first so the
+        result can report how many were removed.
+        """
+        try:
+            if track_index < 0 or track_index >= len(self._song.tracks):
+                raise IndexError("Track index out of range")
+
+            track = self._song.tracks[track_index]
+
+            if clip_index < 0 or clip_index >= len(track.clip_slots):
+                raise IndexError("Clip index out of range")
+
+            clip_slot = track.clip_slots[clip_index]
+
+            if not clip_slot.has_clip:
+                raise Exception("No clip in slot")
+
+            clip = clip_slot.clip
+
+            if not clip.is_midi_clip:
+                raise Exception("Clip is not a MIDI clip; no notes to clear")
+
+            length = clip.length
+
+            # Count existing notes for the report (best-effort; never fatal).
+            cleared = 0
+            try:
+                getter = getattr(clip, "get_notes_extended", None)
+                if getter is not None:
+                    cleared = len(list(getter(0, 128, 0.0, length)))
+                else:
+                    cleared = len(list(clip.get_notes(0.0, 0, length, 128)))
+            except Exception:
+                cleared = 0
+
+            # Remove every note across the full pitch/time range. Prefer the
+            # modern API (Live 11+); fall back to the legacy signature. Argument
+            # order mirrors the get/remove _extended family:
+            #   remove_notes_extended(from_pitch, pitch_span, from_time, time_span)
+            # vs the legacy remove_notes(from_time, from_pitch, time_span, pitch_span).
+            remover = getattr(clip, "remove_notes_extended", None)
+            if remover is not None:
+                remover(0, 128, 0.0, length)
+            else:
+                clip.remove_notes(0.0, 0, length, 128)
+
+            return {
+                "track_index": track_index,
+                "clip_index": clip_index,
+                "clip_name": clip.name,
+                "cleared_count": cleared,
+            }
+        except Exception as e:
+            self.log_message("Error clearing notes from clip: " + str(e))
             raise
 
     def _duplicate_session_clip_to_arrangement(self, track_index, clip_index, destination_time):

--- a/INTEGRATION_TEST.md
+++ b/INTEGRATION_TEST.md
@@ -1,0 +1,104 @@
+# Integration test — get_notes_from_clip against a live Set
+
+The unit tests (`tests/`) mock Ableton and prove the server's logic. This
+procedure proves the part they can't: that the real Live Object Model calls
+(`get_notes_extended`, `is_midi_clip`, `set_notes`) behave as the handler
+assumes. Run it once against a real Set; it's pass/fail, not vibes.
+
+## Prerequisites
+
+- Ableton Live open with the **patched** AbletonMCP Remote Script loaded
+  (control surface selected; if notes read back at all, you're loaded).
+- The MCP server running from the patched clone, connected to your assistant.
+- One MIDI track with an **empty clip slot** you don't mind using as scratch.
+  The steps below assume track index `T` and empty slot index `S` — substitute
+  your own. (Track/slot indices are 0-based.)
+
+## Read-back quirks to expect (NOT failures)
+
+- **Order isn't preserved.** Live may return notes sorted by time/pitch, not in
+  the order you wrote them. Compare as an unordered set of notes.
+- **Ints come back as floats.** Velocity `100` may read as `100.0`; same for
+  start/duration. Compare numerically, not by type.
+- **Extra fields appear.** Each read note may carry `note_id`, `probability`,
+  `velocity_deviation`, `release_velocity`. Expected — ignore them. They ride
+  back through `add_notes_to_clip` harmlessly.
+
+---
+
+## Step 1 — create an empty clip and read it (zero notes)
+
+Ask the assistant to create a 4-beat MIDI clip at track `T`, slot `S`, then
+read its notes.
+
+**Expected:** read reports the clip name and `0 note(s)`, notes list `[]`.
+**Pass:** no error; empty note list on a freshly created clip.
+
+## Step 2 — write a known pattern, then read it back
+
+Write exactly these three notes to track `T`, slot `S`:
+
+| pitch | start_time | duration | velocity | mute  |
+|------:|-----------:|---------:|---------:|-------|
+| 36    | 0.0        | 0.25     | 100      | false |
+| 38    | 1.0        | 0.25     | 90       | false |
+| 42    | 0.5        | 0.25     | 80       | true  |
+
+Then read the clip.
+
+**Expected:** read reports `3 note(s)`. Ignoring order/float/extra-field quirks
+above, the three notes match the table exactly — including `mute: true` on
+pitch 42 and the three distinct velocities.
+**Pass:** all three notes present with correct pitch/start/duration/velocity/
+mute. This is the core proof: what Live returns equals what you wrote.
+
+## Step 3 — read → modify → clear → write → read (the real replace loop)
+
+Take the notes from Step 2 and transpose every pitch up 7 semitones
+(36→43, 38→45, 42→49). Then, in order: **clear** the clip
+(`clear_notes_from_clip`), **write** the transposed notes
+(`add_notes_to_clip`), and read again.
+
+**Expected:** read reports exactly **3** notes — pitches `43, 45, 49`, other
+fields unchanged.
+**Pass:** the clip holds *only* the modified notes.
+
+> Why the clear step matters: `add_notes_to_clip` is **additive** — it appends,
+> it doesn't replace. Skip the clear and you'd read back 6 notes (the original
+> three plus the transposed three). Clearing first is what turns "add" into a
+> genuine read → modify → write loop. This is exactly the gap
+> `clear_notes_from_clip` exists to close.
+
+## Step 4 — error path: empty slot
+
+Read notes from a slot you know is **empty** (no clip).
+
+**Expected:** an error message containing `No clip in slot` (not a crash, not
+an empty success).
+**Pass:** clean, descriptive error.
+
+## Step 5 — error path: audio clip (optional)
+
+If you have an audio track with a clip, read its notes.
+
+**Expected:** an error containing `not a MIDI clip`.
+**Pass:** clean, descriptive error — the `is_midi_clip` guard works.
+
+> `clear_notes_from_clip` shares the same guards (`No clip in slot`,
+> `not a MIDI clip`), so Steps 4–5 cover it too; no separate steps needed.
+
+---
+
+## Cleanup
+
+Delete the scratch clip (or leave it — it's disposable). Nothing else to undo.
+
+## Recording the result for the PR
+
+Note Live version, OS, and which steps passed, e.g.:
+
+> Verified on Live 12.4.2 / macOS: steps 1–5 pass. Notes round-trip exactly
+> (order differs and ints return as floats, as documented).
+
+That line in the PR tells a reviewer the LOM half was checked on real hardware,
+which the unit tests can't assert.

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -113,6 +113,7 @@ class AbletonConnection:
         is_modifying_command = command_type in [
             "create_midi_track", "create_audio_track", "set_track_name",
             "create_clip", "create_audio_clip", "add_notes_to_clip", "set_clip_name",
+            "clear_notes_from_clip",
             "set_tempo", "fire_clip", "stop_clip", "set_device_parameter",
             "start_playback", "stop_playback", "load_instrument_or_effect",
             # Arrangement view commands
@@ -422,6 +423,88 @@ def add_notes_to_clip(
     except Exception as e:
         logger.error(f"Error adding notes to clip: {str(e)}")
         return f"Error adding notes to clip: {str(e)}"
+
+@mcp.tool()
+@rich_telemetry_tool("get_notes_from_clip")
+def get_notes_from_clip(
+    ctx: Context,
+    track_index: int,
+    clip_index: int,
+    user_prompt: str = ""
+) -> str:
+    """
+    Read the MIDI notes currently in a Session clip.
+
+    Returns the notes as JSON so they can be inspected, edited, and written
+    back with add_notes_to_clip. Each note has pitch, start_time, duration,
+    velocity, and mute; richer fields (note_id, probability,
+    velocity_deviation, release_velocity) are included when Live exposes them.
+    Use this to iterate on an existing clip (read -> modify -> write) instead
+    of regenerating it from memory, and to see edits made by hand in Live.
+
+    Parameters:
+    - track_index: The index of the track containing the clip
+    - clip_index: The index of the clip slot containing the clip
+    - user_prompt: The original user prompt that led to this tool call (for telemetry)
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("get_notes_from_clip", {
+            "track_index": track_index,
+            "clip_index": clip_index
+        })
+        notes = result.get("notes", [])
+        header = (
+            "Clip '{name}' (track {t}, slot {c}) — {n} note(s), {length} beats:".format(
+                name=result.get("clip_name", "clip"),
+                t=track_index,
+                c=clip_index,
+                n=result.get("note_count", len(notes)),
+                length=result.get("length", "?"),
+            )
+        )
+        return header + "\n" + json.dumps(notes, indent=2)
+    except Exception as e:
+        logger.error(f"Error getting notes from clip: {str(e)}")
+        return f"Error getting notes from clip: {str(e)}"
+
+@mcp.tool()
+@rich_telemetry_tool("clear_notes_from_clip")
+def clear_notes_from_clip(
+    ctx: Context,
+    track_index: int,
+    clip_index: int,
+    user_prompt: str = ""
+) -> str:
+    """
+    Remove all MIDI notes from a Session clip.
+
+    Writes are additive (add_notes_to_clip only appends), so to truly *modify*
+    a clip you clear it first, then add the new notes. Use this with
+    get_notes_from_clip and add_notes_to_clip for a real read -> modify -> write
+    loop: read the notes, edit the list, clear_notes_from_clip, then
+    add_notes_to_clip the edited notes.
+
+    Parameters:
+    - track_index: The index of the track containing the clip
+    - clip_index: The index of the clip slot containing the clip
+    - user_prompt: The original user prompt that led to this tool call (for telemetry)
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("clear_notes_from_clip", {
+            "track_index": track_index,
+            "clip_index": clip_index
+        })
+        return "Cleared {n} note(s) from clip '{name}' (track {t}, slot {c})".format(
+            n=result.get("cleared_count", "?"),
+            name=result.get("clip_name", "clip"),
+            t=track_index,
+            c=clip_index,
+        )
+    except Exception as e:
+        logger.error(f"Error clearing notes from clip: {str(e)}")
+        return f"Error clearing notes from clip: {str(e)}"
 
 @mcp.tool()
 @rich_telemetry_tool("set_clip_name")

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,52 @@
+# Tests
+
+Server-side unit tests for the MCP tools. They mock the Ableton socket
+connection, so they run anywhere — no Ableton, no network, deterministic.
+
+## Run
+
+From the repo root:
+
+```bash
+# quickest — pytest pulled in just for this run, no pyproject change:
+uv run --with pytest pytest -v
+
+# or if you've added pytest as a dev dependency (see below):
+uv run pytest -v
+
+# or in any venv that already has the server's deps + pytest:
+python -m pytest -v
+```
+
+## What's covered
+
+`tests/test_get_notes_from_clip.py` exercises the real
+`MCP_Server.server` tool functions with a `FakeConnection` substituted for the
+live Ableton link:
+
+- `get_notes_from_clip` sends the correct command and params
+- output header (clip name / note count / length) and JSON body are correct
+- empty clip returns zero notes, not an error
+- a connection exception is caught and reported, not raised
+- a response missing metadata (older Remote Script) degrades gracefully
+- **round-trip:** read output feeds straight into `add_notes_to_clip`, and a
+  read -> transpose -> write cycle yields the expected pitches
+- `add_notes_to_clip` regression: still forwards track/clip/notes
+
+## What these tests do NOT cover
+
+The actual Live Object Model calls (`get_notes_extended`, `clip.is_midi_clip`,
+`set_notes`) only run inside Ableton's embedded Python. These tests stop at the
+socket boundary. The Live-side behaviour is verified with the manual
+integration checklist (run once against a real Set).
+
+## Adding pytest as a dev dependency (optional, for CI)
+
+In `pyproject.toml`:
+
+```toml
+[dependency-groups]
+dev = ["pytest>=8"]
+```
+
+Then `uv sync --group dev` and `uv run pytest -v`.

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,4 @@
+# Ensures `import MCP_Server.server` resolves no matter how pytest is invoked.
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))

--- a/tests/test_get_notes_from_clip.py
+++ b/tests/test_get_notes_from_clip.py
@@ -1,0 +1,222 @@
+"""
+Server-side tests for get_notes_from_clip (and its pairing with
+add_notes_to_clip). These exercise the real MCP_Server.server tool functions
+with the Ableton socket connection mocked, so they run anywhere — no Ableton,
+no network.
+
+Run from the repo root:
+    uv run pytest -v
+    # or, in any env that has the server's deps:
+    python -m pytest -v
+"""
+
+import json
+import pytest
+
+import MCP_Server.server as server
+
+
+# --------------------------------------------------------------------------
+# Test doubles
+# --------------------------------------------------------------------------
+
+class FakeConnection:
+    """Stand-in for AbletonConnection. Records every command sent and returns
+    a canned response (or raises) so we can test the tool logic in isolation."""
+
+    def __init__(self, response=None, raise_exc=None):
+        self.response = {} if response is None else response
+        self.raise_exc = raise_exc
+        self.sent = []  # list of (command_type, params) tuples
+
+    def send_command(self, command_type, params=None):
+        self.sent.append((command_type, params or {}))
+        if self.raise_exc is not None:
+            raise self.raise_exc
+        return self.response
+
+
+@pytest.fixture
+def fake_conn(monkeypatch):
+    """Factory: install a FakeConnection as the active Ableton connection and
+    return it so the test can inspect what was sent."""
+    def _make(response=None, raise_exc=None):
+        conn = FakeConnection(response=response, raise_exc=raise_exc)
+        monkeypatch.setattr(server, "get_ableton_connection", lambda: conn)
+        return conn
+    return _make
+
+
+@pytest.fixture(autouse=True)
+def _silence_telemetry(monkeypatch):
+    """Make the telemetry side-effect in the tool decorators a no-op, so tests
+    are hermetic and never touch the network."""
+    class _Dummy:
+        def record_event(self, *a, **k):
+            pass
+    import MCP_Server.telemetry_decorator as td
+    monkeypatch.setattr(td, "get_telemetry", lambda: _Dummy(), raising=False)
+
+
+# A representative clip payload as the Remote Script would return it.
+SAMPLE_NOTES = [
+    {"pitch": 36, "start_time": 0.0, "duration": 0.25, "velocity": 100, "mute": False, "note_id": 1},
+    {"pitch": 38, "start_time": 1.0, "duration": 0.50, "velocity": 90, "mute": True, "note_id": 2},
+    {"pitch": 42, "start_time": 2.0, "duration": 0.25, "velocity": 80, "mute": False, "note_id": 3},
+]
+
+
+def _sample_response(notes=SAMPLE_NOTES, name="Fred Pattern", length=8.0):
+    return {"clip_name": name, "length": length,
+            "note_count": len(notes), "notes": notes}
+
+
+# --------------------------------------------------------------------------
+# get_notes_from_clip
+# --------------------------------------------------------------------------
+
+def test_sends_correct_command_and_params(fake_conn):
+    conn = fake_conn(response=_sample_response())
+    server.get_notes_from_clip(None, track_index=2, clip_index=5)
+    assert conn.sent == [("get_notes_from_clip", {"track_index": 2, "clip_index": 5})]
+
+
+def test_output_header_reports_name_count_and_length(fake_conn):
+    fake_conn(response=_sample_response(name="Fred Pattern", length=8.0))
+    out = server.get_notes_from_clip(None, 0, 0)
+    header = out.splitlines()[0]
+    assert "Fred Pattern" in header
+    assert "3 note" in header
+    assert "8.0 beats" in header
+
+
+def test_output_json_parses_back_to_the_notes(fake_conn):
+    fake_conn(response=_sample_response())
+    out = server.get_notes_from_clip(None, 0, 0)
+    json_block = out.split("\n", 1)[1]
+    assert json.loads(json_block) == SAMPLE_NOTES
+
+
+def test_empty_clip_is_zero_notes_not_an_error(fake_conn):
+    fake_conn(response=_sample_response(notes=[], name="Empty", length=4.0))
+    out = server.get_notes_from_clip(None, 0, 0)
+    assert "0 note" in out.splitlines()[0]
+    assert json.loads(out.split("\n", 1)[1]) == []
+
+
+def test_connection_error_is_caught_and_reported(fake_conn):
+    fake_conn(raise_exc=Exception("socket boom"))
+    out = server.get_notes_from_clip(None, 0, 0)
+    assert out.startswith("Error getting notes from clip:")
+    assert "socket boom" in out
+
+
+def test_missing_metadata_falls_back_gracefully(fake_conn):
+    # An older Remote Script might return only the notes list.
+    fake_conn(response={"notes": []})
+    out = server.get_notes_from_clip(None, 0, 0)
+    # falls back to len(notes) and placeholder name/length, no crash
+    assert "0 note" in out.splitlines()[0]
+
+
+# --------------------------------------------------------------------------
+# The whole point of #11: read -> modify -> write round-trip
+# --------------------------------------------------------------------------
+
+def test_read_output_feeds_straight_into_add_notes(fake_conn):
+    conn = fake_conn(response=_sample_response())
+    out = server.get_notes_from_clip(None, 0, 0)
+    parsed = json.loads(out.split("\n", 1)[1])
+
+    # Now write those same notes back. The extra note_id field must ride along
+    # harmlessly (add_notes_to_clip forwards the dicts as-is).
+    server.add_notes_to_clip(None, track_index=0, clip_index=0, notes=parsed)
+    add_cmd = [c for c in conn.sent if c[0] == "add_notes_to_clip"][-1]
+    assert add_cmd[1]["notes"] == parsed
+    # core fields survive the round-trip untouched
+    assert add_cmd[1]["notes"][0]["pitch"] == 36
+    assert add_cmd[1]["notes"][1]["mute"] is True
+
+
+def test_modify_then_write(fake_conn):
+    conn = fake_conn(response=_sample_response())
+    out = server.get_notes_from_clip(None, 0, 0)
+    notes = json.loads(out.split("\n", 1)[1])
+
+    # transpose up a fifth, as an agent editing the loop might
+    for n in notes:
+        n["pitch"] += 7
+    server.add_notes_to_clip(None, 0, 0, notes)
+
+    written = [c for c in conn.sent if c[0] == "add_notes_to_clip"][-1][1]["notes"]
+    assert [n["pitch"] for n in written] == [43, 45, 49]
+
+
+# --------------------------------------------------------------------------
+# add_notes_to_clip regression (the existing write path still behaves)
+# --------------------------------------------------------------------------
+
+def test_add_notes_forwards_track_clip_and_notes(fake_conn):
+    conn = fake_conn(response={"note_count": 1})
+    notes = [{"pitch": 60, "start_time": 0.0, "duration": 1.0, "velocity": 100, "mute": False}]
+    out = server.add_notes_to_clip(None, 7, 3, notes)
+    assert conn.sent[-1] == (
+        "add_notes_to_clip",
+        {"track_index": 7, "clip_index": 3, "notes": notes},
+    )
+    assert "Added 1 notes" in out
+
+
+# --------------------------------------------------------------------------
+# clear_notes_from_clip  +  the true replace loop
+# --------------------------------------------------------------------------
+
+def test_clear_sends_correct_command_and_params(fake_conn):
+    conn = fake_conn(response={"clip_name": "Fred", "cleared_count": 3})
+    server.clear_notes_from_clip(None, track_index=1, clip_index=4)
+    assert conn.sent == [("clear_notes_from_clip", {"track_index": 1, "clip_index": 4})]
+
+
+def test_clear_output_reports_count_and_name(fake_conn):
+    fake_conn(response={"clip_name": "Fred Pattern", "cleared_count": 5})
+    out = server.clear_notes_from_clip(None, 0, 0)
+    assert "Cleared 5 note" in out
+    assert "Fred Pattern" in out
+
+
+def test_clear_connection_error_is_reported(fake_conn):
+    fake_conn(raise_exc=Exception("boom"))
+    out = server.clear_notes_from_clip(None, 0, 0)
+    assert out.startswith("Error clearing notes from clip:")
+    assert "boom" in out
+
+
+def test_true_replace_loop_read_clear_add(fake_conn):
+    """The whole point of clear_notes_from_clip: read -> modify -> clear ->
+    write yields a clip that holds ONLY the modified notes (not the union)."""
+    conn = fake_conn(response=_sample_response())
+
+    # read
+    out = server.get_notes_from_clip(None, 0, 0)
+    notes = json.loads(out.split("\n", 1)[1])
+
+    # modify: transpose up a fifth
+    for n in notes:
+        n["pitch"] += 7
+
+    # clear, then write the modified notes back
+    conn.response = {"clip_name": "Fred Pattern", "cleared_count": 3}
+    server.clear_notes_from_clip(None, 0, 0)
+    conn.response = {"note_count": 3}
+    server.add_notes_to_clip(None, 0, 0, notes)
+
+    # the command sequence is read -> clear -> add, in that order
+    assert [c[0] for c in conn.sent] == [
+        "get_notes_from_clip", "clear_notes_from_clip", "add_notes_to_clip",
+    ]
+    # clear targeted the same slot
+    clear_cmd = [c for c in conn.sent if c[0] == "clear_notes_from_clip"][0]
+    assert clear_cmd[1] == {"track_index": 0, "clip_index": 0}
+    # and the only notes written back are the transposed ones
+    written = [c for c in conn.sent if c[0] == "add_notes_to_clip"][0][1]["notes"]
+    assert [n["pitch"] for n in written] == [43, 45, 49]


### PR DESCRIPTION
# Add MIDI note read-back and clear (`get_notes_from_clip`, `clear_notes_from_clip`)

## Summary

AbletonMCP can author MIDI clips but can't inspect or truly modify them:
`add_notes_to_clip` is the only note-path tool, it's write-only, and it's
purely additive. This PR adds the two missing primitives so an agent can do a
real **read → modify → write** loop:

- **`get_notes_from_clip`** — read the notes currently in a Session clip.
- **`clear_notes_from_clip`** — remove all notes from a clip.

With the existing `add_notes_to_clip`, "modify a loop" becomes: read → edit the
note list → clear → add. Today it can only ever mean "append on top of what's
already there."

## Why it matters

Without read-back, every "iterate on this clip" request forces the model to
hold the entire note state in context and regenerate it from memory, and it's
blind to any edits made by hand in Live — it can't verify what actually landed
or build on a human's manual changes. And because writes are additive, there's
no way to replace a clip's contents; "modify" silently means "add more." These
two tools close both gaps.

## Not an API ceiling — just unwrapped

This is a server gap, not a limitation of Live. The Live Object Model already
exposes note reading via `Clip.get_notes_extended()` (and legacy `get_notes()`)
and removal via `Clip.remove_notes_extended()` (legacy `remove_notes()`). The
server simply never wrapped them.

## Design notes worth a reviewer's eye

- **Argument-order footgun.** `get_notes_extended(from_pitch, pitch_span,
  from_time, time_span)` is **pitch-first** — the opposite order of the legacy
  `get_notes(from_time, from_pitch, time_span, pitch_span)`. Both new handlers
  call the extended form with a legacy fallback for older Live, and the
  comments flag the ordering so the next contributor doesn't invert it.
- **Thread placement.** `get_notes_from_clip` is read-only and runs off the
  main thread, matching the existing read tools (`get_arrangement_clips`,
  `get_session_info`, `get_track_info`). `clear_notes_from_clip` mutates state,
  so it's scheduled on the main thread and registered in all three places this
  codebase requires: the modifying-command list in `server.py`, the equivalent
  routing list in the Remote Script, and the `main_thread_task` dispatch.
- **Round-trip shape.** Read output is returned in the same dict shape
  `add_notes_to_clip` consumes (`pitch, start_time, duration, velocity, mute`),
  so notes can be read, edited, and written straight back. Richer per-note
  fields (`note_id`, `probability`, `velocity_deviation`, `release_velocity`)
  are included when Live exposes them and ride back through `add_notes_to_clip`
  harmlessly.
- **Additive and low-risk.** No existing tool or behavior is changed; both
  tools are pure additions.

## Testing

**Unit (`tests/`, 13 tests).** Exercise the real server tool functions with the
Ableton socket connection mocked — command/param correctness, output
formatting, empty-clip and error paths, and the full read → clear → add replace
loop. No Ableton or network needed:

```bash
uv run --with pytest pytest -v
```

**Integration (`INTEGRATION_TEST.md`).** A documented, repeatable pass/fail
procedure against a real Set, covering the round-trip and both error guards.
Verified on **Live 12.4.2 / macOS**: notes round-trip exactly (Live reorders
notes on read-back and returns ints as floats — both documented as expected),
and the `No clip in slot` / `not a MIDI clip` guards fire cleanly. The unit
tests deliberately stop at the socket boundary; this procedure covers the
actual LOM calls they can't reach.

## Files touched

- `MCP_Server/server.py` — the two tools, plus `clear_notes_from_clip` added to
  the modifying-command classification.
- `AbletonMCP_Remote_Script/__init__.py` — the two handlers, dispatch wiring,
  and main-thread scheduling for the clear command.
- `tests/`, `conftest.py`, `TESTING.md`, `INTEGRATION_TEST.md` — test suite and
  procedures (new).
