### PR TITLE
Add delete_clip: clear a Session clip slot

### DIFF
--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -229,6 +229,7 @@ class AbletonMCP(ControlSurface):
             # Commands that modify Live's state should be scheduled on the main thread
             elif command_type in ["create_midi_track", "set_track_name",
                                  "create_clip", "create_audio_clip", "add_notes_to_clip", "set_clip_name",
+                                 "delete_clip",
                                  "set_tempo", "fire_clip", "stop_clip",
                                  "start_playback", "stop_playback", "load_browser_item",
                                  # Arrangement view – must run on the main thread
@@ -279,6 +280,10 @@ class AbletonMCP(ControlSurface):
                             track_index = params.get("track_index", 0)
                             clip_index = params.get("clip_index", 0)
                             result = self._stop_clip(track_index, clip_index)
+                        elif command_type == "delete_clip":
+                            track_index = params.get("track_index", 0)
+                            clip_index = params.get("clip_index", 0)
+                            result = self._delete_clip(track_index, clip_index)
                         elif command_type == "start_playback":
                             result = self._start_playback()
                         elif command_type == "stop_playback":
@@ -709,8 +714,31 @@ class AbletonMCP(ControlSurface):
         except Exception as e:
             self.log_message("Error stopping clip: " + str(e))
             raise
-    
-    
+
+    def _delete_clip(self, track_index, clip_index):
+        """Delete the clip in the given clip slot, freeing the slot for reuse."""
+        try:
+            if track_index < 0 or track_index >= len(self._song.tracks):
+                raise IndexError("Track index out of range")
+
+            track = self._song.tracks[track_index]
+
+            if clip_index < 0 or clip_index >= len(track.clip_slots):
+                raise IndexError("Clip index out of range")
+
+            clip_slot = track.clip_slots[clip_index]
+
+            if not clip_slot.has_clip:
+                return {"deleted": False, "reason": "Clip slot was already empty"}
+
+            clip_slot.delete_clip()
+
+            return {"deleted": True}
+        except Exception as e:
+            self.log_message("Error deleting clip: " + str(e))
+            raise
+
+
     def _start_playback(self):
         """Start playing the session"""
         try:

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -542,6 +542,33 @@ def stop_clip(ctx: Context, track_index: int, clip_index: int, user_prompt: str 
         logger.error(f"Error stopping clip: {str(e)}")
         return f"Error stopping clip: {str(e)}"
 
+
+@mcp.tool()
+@telemetry_tool("delete_clip")
+def delete_clip(ctx: Context, track_index: int, clip_index: int, user_prompt: str = "") -> str:
+    """
+    Delete the clip in the given clip slot, freeing it for reuse.
+
+    Use this before create_clip when you want to overwrite an existing clip
+    (create_clip itself refuses to write into an occupied slot).
+
+    Parameters:
+    - track_index: The index of the track containing the clip
+    - clip_index: The index of the clip slot to clear
+    - user_prompt: The original user prompt that led to this tool call (for telemetry)
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("delete_clip", {
+            "track_index": track_index,
+            "clip_index": clip_index,
+        })
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        logger.error(f"Error deleting clip: {str(e)}")
+        return f"Error deleting clip: {str(e)}"
+
+
 @mcp.tool()
 @telemetry_tool("start_playback")
 def start_playback(ctx: Context, user_prompt: str = "") -> str:


### PR DESCRIPTION
## Summary
Adds a `delete_clip` MCP tool plus matching Remote Script command that deletes the clip in a given clip slot.

This is useful because `create_clip` refuses to write into an occupied slot — currently there's no way through the MCP layer to free a slot for reuse. With this tool an agent can clear a slot before recreating it.

Returns `{deleted: true}` on success, or `{deleted: false, reason: ...}` if the slot was already empty (idempotent — no error thrown).

## What changed
- `AbletonMCP_Remote_Script/__init__.py`: register `delete_clip` in the main-thread command list, add dispatcher branch, add `_delete_clip` method using `clip_slot.delete_clip()`
- `MCP_Server/server.py`: add `delete_clip(track_index, clip_index)` MCP tool

## Test plan
- [x] Manually verified in Live 12 — deleting an occupied slot frees it for a subsequent `create_clip` call
- [x] Verified the empty-slot path returns the idempotent `{deleted: false}` response without raising

🤖 Generated with [Claude Code](https://claude.com/claude-code)