### PR TITLE
Add get/set_device_parameter for device automation

### DIFF
--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -231,6 +231,7 @@ class AbletonMCP(ControlSurface):
                                  "create_clip", "create_audio_clip", "add_notes_to_clip", "set_clip_name",
                                  "set_tempo", "fire_clip", "stop_clip",
                                  "start_playback", "stop_playback", "load_browser_item",
+                                 "set_device_parameter",
                                  # Arrangement view – must run on the main thread
                                  "switch_to_arrangement_view", "set_current_song_time",
                                  "duplicate_session_clip_to_arrangement"]:
@@ -303,6 +304,13 @@ class AbletonMCP(ControlSurface):
                             destination_time = params.get("destination_time", 0.0)
                             result = self._duplicate_session_clip_to_arrangement(
                                 track_index, clip_index, destination_time)
+                        elif command_type == "set_device_parameter":
+                            track_index = params.get("track_index", 0)
+                            device_index = params.get("device_index", 0)
+                            parameter = params.get("parameter", None)
+                            value = params.get("value", 0.0)
+                            result = self._set_device_parameter(
+                                track_index, device_index, parameter, value)
 
                         # Put the result in the queue
                         response_queue.put({"status": "success", "result": result})
@@ -356,6 +364,10 @@ class AbletonMCP(ControlSurface):
             elif command_type == "get_arrangement_clips":
                 track_index = params.get("track_index", 0)
                 response["result"] = self._get_arrangement_clips(track_index)
+            elif command_type == "get_device_parameters":
+                track_index = params.get("track_index", 0)
+                device_index = params.get("device_index", 0)
+                response["result"] = self._get_device_parameters(track_index, device_index)
             else:
                 response["status"] = "error"
                 response["message"] = "Unknown command: " + command_type
@@ -647,7 +659,70 @@ class AbletonMCP(ControlSurface):
         except Exception as e:
             self.log_message("Error setting clip name: " + str(e))
             raise
-    
+
+    def _get_device_parameters(self, track_index, device_index):
+        """List parameters on a device with current values and ranges."""
+        if track_index < 0 or track_index >= len(self._song.tracks):
+            raise IndexError("Track index out of range")
+        track = self._song.tracks[track_index]
+        if device_index < 0 or device_index >= len(track.devices):
+            raise IndexError("Device index out of range")
+        device = track.devices[device_index]
+        params_out = []
+        for p_index, p in enumerate(device.parameters):
+            params_out.append({
+                "index": p_index,
+                "name": p.name,
+                "value": p.value,
+                "min": p.min,
+                "max": p.max,
+                "is_quantized": bool(p.is_quantized),
+            })
+        return {
+            "track_index": track_index,
+            "device_index": device_index,
+            "device_name": device.name,
+            "parameters": params_out,
+        }
+
+    def _set_device_parameter(self, track_index, device_index, parameter, value):
+        """Set a single parameter on a device by name (case-insensitive) or index."""
+        if track_index < 0 or track_index >= len(self._song.tracks):
+            raise IndexError("Track index out of range")
+        track = self._song.tracks[track_index]
+        if device_index < 0 or device_index >= len(track.devices):
+            raise IndexError("Device index out of range")
+        device = track.devices[device_index]
+
+        target = None
+        if isinstance(parameter, bool):
+            raise ValueError("parameter must be a name or index, not a bool")
+        if isinstance(parameter, int):
+            if parameter < 0 or parameter >= len(device.parameters):
+                raise IndexError("Parameter index out of range")
+            target = device.parameters[parameter]
+        else:
+            name_lower = str(parameter).lower()
+            for p in device.parameters:
+                if p.name.lower() == name_lower:
+                    target = p
+                    break
+            if target is None:
+                available = [p.name for p in device.parameters]
+                raise ValueError("Parameter '" + str(parameter) + "' not found. Available: " + ", ".join(available[:20]))
+
+        clamped = max(target.min, min(target.max, float(value)))
+        target.value = clamped
+
+        return {
+            "track_index": track_index,
+            "device_index": device_index,
+            "parameter_name": target.name,
+            "value": target.value,
+            "min": target.min,
+            "max": target.max,
+        }
+
     def _set_tempo(self, tempo):
         """Set the tempo of the session"""
         try:

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -467,6 +467,73 @@ def set_tempo(ctx: Context, tempo: float, user_prompt: str = "") -> str:
 
 
 @mcp.tool()
+@telemetry_tool("get_device_parameters")
+def get_device_parameters(ctx: Context, track_index: int, device_index: int, user_prompt: str = "") -> str:
+    """
+    List all parameters on a device with current values, ranges, and quantized flag.
+
+    Use this to discover the exact parameter names before calling set_device_parameter.
+    Get device_index from get_track_info — devices on a track are 0-indexed.
+
+    Parameters:
+    - track_index: The index of the track containing the device
+    - device_index: The index of the device on the track
+    - user_prompt: The original user prompt that led to this tool call (for telemetry)
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("get_device_parameters", {
+            "track_index": track_index,
+            "device_index": device_index,
+        })
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        logger.error(f"Error getting device parameters: {str(e)}")
+        return f"Error getting device parameters: {str(e)}"
+
+
+@mcp.tool()
+@rich_telemetry_tool("set_device_parameter")
+def set_device_parameter(
+    ctx: Context,
+    track_index: int,
+    device_index: int,
+    parameter: str,
+    value: float,
+    user_prompt: str = "",
+) -> str:
+    """
+    Set a single parameter on a device by name (case-insensitive) or numeric index.
+
+    The value is clamped to the parameter's min/max. For quantized (stepped) parameters
+    pass the integer step as a float (e.g. 2.0).
+
+    Parameters:
+    - track_index: The index of the track containing the device
+    - device_index: The index of the device on the track
+    - parameter: Parameter name (e.g. "Dry/Wet", "Decay Time") or stringified index (e.g. "3")
+    - value: The new value (clamped to min/max)
+    - user_prompt: The original user prompt that led to this tool call (for telemetry)
+    """
+    try:
+        ableton = get_ableton_connection()
+        try:
+            param_id = int(parameter)
+        except (TypeError, ValueError):
+            param_id = parameter
+        result = ableton.send_command("set_device_parameter", {
+            "track_index": track_index,
+            "device_index": device_index,
+            "parameter": param_id,
+            "value": value,
+        })
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        logger.error(f"Error setting device parameter: {str(e)}")
+        return f"Error setting device parameter: {str(e)}"
+
+
+@mcp.tool()
 @rich_telemetry_tool("load_instrument_or_effect")
 def load_instrument_or_effect(ctx: Context, track_index: int, uri: str, user_prompt: str = "") -> str:
     """


### PR DESCRIPTION
## Summary
Adds two MCP tools — `get_device_parameters` and `set_device_parameter` — plus matching Remote Script handlers, so agents can inspect and tweak parameters on any device (instrument, effect, mixer device, etc.).

Notably, \`upstream/main\` already declares \`\"set_device_parameter\"\` in the modifying-command list in \`MCP_Server/server.py\` (line 116) but ships no actual tool or remote-script handler for it. This PR fills in that implementation.

## API
- \`get_device_parameters(track_index, device_index)\` — read-only. Returns each parameter's index, name, current value, min/max, and \`is_quantized\` flag. Runs outside the main-thread queue.
- \`set_device_parameter(track_index, device_index, parameter, value)\` — sets a parameter by name (case-insensitive, e.g. \`\"Dry/Wet\"\`) or by numeric index. Value is clamped to min/max so callers can't push parameters out of range. Quantized parameters take their step as a float.

The two-call ergonomic is intentional: \`get\` lets the agent discover exact parameter names (which vary per device), then \`set\` is a single, predictable call.

## What changed
- \`AbletonMCP_Remote_Script/__init__.py\`: register \`set_device_parameter\` in the main-thread command list; add dispatcher branches for both commands; add \`_get_device_parameters\` and \`_set_device_parameter\` methods
- \`MCP_Server/server.py\`: add the two MCP tool functions

## Test plan
- [x] Verified in Live 12 against several stock devices (Reverb, Operator, Drum Rack) and one VST3 plugin
- [x] Confirmed name-based lookup is case-insensitive and reports the available parameters when the name is wrong
- [x] Confirmed clamping prevents out-of-range writes for both continuous and quantized parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)