### PR TITLE
Add create_locator: place named markers in the Arrangement

### DIFF
--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -233,7 +233,8 @@ class AbletonMCP(ControlSurface):
                                  "start_playback", "stop_playback", "load_browser_item",
                                  # Arrangement view – must run on the main thread
                                  "switch_to_arrangement_view", "set_current_song_time",
-                                 "duplicate_session_clip_to_arrangement"]:
+                                 "duplicate_session_clip_to_arrangement",
+                                 "create_locator"]:
                 # Use a thread-safe approach with a response queue
                 response_queue = queue.Queue()
                 
@@ -303,6 +304,10 @@ class AbletonMCP(ControlSurface):
                             destination_time = params.get("destination_time", 0.0)
                             result = self._duplicate_session_clip_to_arrangement(
                                 track_index, clip_index, destination_time)
+                        elif command_type == "create_locator":
+                            name = params.get("name", "")
+                            time_val = params.get("time", 0.0)
+                            result = self._create_locator(name, time_val)
 
                         # Put the result in the queue
                         response_queue.put({"status": "success", "result": result})
@@ -834,6 +839,60 @@ class AbletonMCP(ControlSurface):
             }
         except Exception as e:
             self.log_message("Error duplicating clip to arrangement: " + str(e))
+            raise
+
+    def _create_locator(self, name, time_val):
+        """Create (or rename) a named locator at the given beat position.
+
+        Uses Live's Song.set_or_delete_cue(), which toggles a cue at the
+        current_song_time. We temporarily move the playhead, toggle, then
+        restore. If a cue already exists at that time we just rename it
+        instead of toggling (which would delete it).
+        """
+        try:
+            song = self._song
+            target_time = float(time_val)
+            tolerance = 1e-3
+
+            # See if a cue already exists at (or near) the target time
+            existing = None
+            for cue in song.cue_points:
+                if abs(cue.time - target_time) < tolerance:
+                    existing = cue
+                    break
+
+            original_time = song.current_song_time
+
+            if existing is None:
+                # Move playhead, toggle to create, then locate the new cue
+                song.current_song_time = target_time
+                song.set_or_delete_cue()
+                for cue in song.cue_points:
+                    if abs(cue.time - target_time) < tolerance:
+                        existing = cue
+                        break
+                # Restore playhead
+                try:
+                    song.current_song_time = original_time
+                except Exception:
+                    pass
+
+            if existing is None:
+                raise Exception("Failed to create cue at time " + str(target_time))
+
+            if name:
+                try:
+                    existing.name = str(name)
+                except Exception as e:
+                    self.log_message("Could not rename locator: " + str(e))
+
+            return {
+                "success": True,
+                "time": existing.time,
+                "name": existing.name,
+            }
+        except Exception as e:
+            self.log_message("Error creating locator: " + str(e))
             raise
 
     # ── Browser implementations ───────────────────────────────────────────────

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -117,7 +117,8 @@ class AbletonConnection:
             "start_playback", "stop_playback", "load_instrument_or_effect",
             # Arrangement view commands
             "switch_to_arrangement_view", "set_current_song_time",
-            "duplicate_session_clip_to_arrangement"
+            "duplicate_session_clip_to_arrangement",
+            "create_locator"
         ]
 
         # Commands whose work on Live's main thread can take noticeably longer
@@ -839,6 +840,41 @@ def duplicate_to_arrangement(
     except Exception as e:
         logger.error(f"Error duplicating clip to arrangement: {str(e)}")
         return f"Error duplicating clip to arrangement: {str(e)}"
+
+
+@mcp.tool()
+@rich_telemetry_tool("create_locator")
+def create_locator(
+    ctx: Context,
+    name: str,
+    time: float,
+    user_prompt: str = ""
+) -> str:
+    """
+    Create a named locator (cue point) in the Arrangement at a beat position.
+
+    If a locator already exists at that beat (within ~1e-3 tolerance) it is
+    renamed instead of toggled off. Time is in beats from the start of the
+    arrangement (e.g. 0.0 = start, 16.0 = bar 5 in 4/4).
+
+    Parameters:
+    - name: The locator label (e.g. "Chorus", "Verse 1", "Drop")
+    - time: Beat position where the locator should sit
+    - user_prompt: The original user prompt that led to this tool call (for telemetry)
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command(
+            "create_locator",
+            {"name": name, "time": time}
+        )
+        return (
+            f"Locator '{result.get('name', name)}' set at beat "
+            f"{result.get('time', time)}"
+        )
+    except Exception as e:
+        logger.error(f"Error creating locator: {str(e)}")
+        return f"Error creating locator: {str(e)}"
 
 
 # Main execution


### PR DESCRIPTION
## Summary
Adds a \`create_locator\` MCP tool plus matching Remote Script command that creates (or renames) a named locator (cue point) at a given beat position in the Arrangement view.

This is useful for AI-driven arrangement workflows: when an agent builds a track section by section, it can label structural points (Intro, Verse, Drop, Outro) as it goes — both for human readability and so subsequent tool calls can reason about song structure.

## Implementation note
Live's Python API only exposes \`Song.set_or_delete_cue()\`, which toggles a cue at the *current* \`current_song_time\`. So the implementation:

1. Looks for an existing cue at the target beat (within \`~1e-3\` tolerance).
2. If none, temporarily moves the playhead to the target beat, calls \`set_or_delete_cue()\`, then restores the playhead.
3. Sets \`.name\` on the resulting cue.

The tolerance check makes the call idempotent — calling \`create_locator(\"Chorus\", 64.0)\` twice gives one locator named \"Chorus\" at beat 64, not a toggled-off cue.

## API
\`create_locator(name: str, time: float)\` — \`time\` is in beats from the start of the arrangement (\`0.0\` = start, \`16.0\` = bar 5 in 4/4).

## What changed
- \`AbletonMCP_Remote_Script/__init__.py\`: register \`create_locator\` in the main-thread command list, add dispatcher branch, add \`_create_locator\` method
- \`MCP_Server/server.py\`: register \`create_locator\` in the modifying-command list, add the MCP tool

## Test plan
- [x] Verified in Live 12 that locators appear at the expected beat with the expected name
- [x] Confirmed idempotency: calling twice with the same args doesn't toggle the cue off
- [x] Confirmed the playhead is restored to its prior position after the call

🤖 Generated with [Claude Code](https://claude.com/claude-code)