### PR TITLE
Add token-efficient tools: batch arrangement, guarded deletes, combined instrument creation, volume automation, sync check

### DIFF
--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -233,7 +233,12 @@ class AbletonMCP(ControlSurface):
                                  "start_playback", "stop_playback", "load_browser_item",
                                  # Arrangement view – must run on the main thread
                                  "switch_to_arrangement_view", "set_current_song_time",
-                                 "duplicate_session_clip_to_arrangement"]:
+                                 "duplicate_session_clip_to_arrangement",
+                                 "delete_clip", "clear_clip_notes", "delete_track",
+                                 "delete_arrangement_clips",
+                                 "duplicate_session_clip_to_arrangement_batch",
+                                 "create_instrument_track",
+                                 "set_track_volume", "create_volume_fade"]:
                 # Use a thread-safe approach with a response queue
                 response_queue = queue.Queue()
                 
@@ -304,6 +309,23 @@ class AbletonMCP(ControlSurface):
                             result = self._duplicate_session_clip_to_arrangement(
                                 track_index, clip_index, destination_time)
 
+                        elif command_type == "delete_clip":
+                            result = self._delete_clip(params.get("track_index", 0), params.get("clip_index", 0), params.get("dry_run", False))
+                        elif command_type == "clear_clip_notes":
+                            result = self._clear_clip_notes(params.get("track_index", 0), params.get("clip_index", 0), params.get("dry_run", False))
+                        elif command_type == "delete_track":
+                            result = self._delete_track(params.get("track_index", 0), params.get("dry_run", False))
+                        elif command_type == "delete_arrangement_clips":
+                            result = self._delete_arrangement_clips(params.get("track_index", 0), params.get("start_time", 0.0), params.get("end_time", 0.0), params.get("dry_run", False))
+                        elif command_type == "duplicate_session_clip_to_arrangement_batch":
+                            result = self._duplicate_session_clip_to_arrangement_batch(params.get("track_index", 0), params.get("clip_index", 0), params.get("destination_time", 0.0), params.get("count", 1), params.get("spacing", 0.0))
+                        elif command_type == "create_instrument_track":
+                            result = self._create_instrument_track(params.get("name","Track"), params.get("uri",""), params.get("clip_length",4.0), params.get("notes",[]), params.get("clip_name"), params.get("index",-1))
+                        elif command_type == "set_track_volume":
+                            result = self._set_track_volume(params.get("track_index",0), params.get("value",0.85))
+                        elif command_type == "create_volume_fade":
+                            result = self._create_volume_fade(params.get("track_index",0), params.get("clip_index",0), params.get("from_value",0.0), params.get("to_value",1.0), params.get("start_time"), params.get("end_time"), params.get("dry_run",False))
+
                         # Put the result in the queue
                         response_queue.put({"status": "success", "result": result})
                     except Exception as e:
@@ -322,7 +344,7 @@ class AbletonMCP(ControlSurface):
                 # create_audio_clip, which decodes/imports the audio file on
                 # the main thread) can take longer than the default 10s on
                 # larger files — give them more headroom.
-                long_running_commands = {"create_audio_clip": 60.0}
+                long_running_commands = {"create_audio_clip": 60.0, "duplicate_session_clip_to_arrangement_batch": 60.0, "create_instrument_track": 60.0}
                 queue_timeout = long_running_commands.get(command_type, 10.0)
                 try:
                     task_response = response_queue.get(timeout=queue_timeout)
@@ -356,6 +378,12 @@ class AbletonMCP(ControlSurface):
             elif command_type == "get_arrangement_clips":
                 track_index = params.get("track_index", 0)
                 response["result"] = self._get_arrangement_clips(track_index)
+            elif command_type == "get_notes_from_clip":
+                response["result"] = self._get_notes_from_clip(params.get("track_index", 0), params.get("clip_index", 0))
+            elif command_type == "get_tracks_overview":
+                response["result"] = self._get_tracks_overview()
+            elif command_type == "check_arrangement_sync":
+                response["result"] = self._check_arrangement_sync(params.get("bar_beats", 4.0))
             else:
                 response["status"] = "error"
                 response["message"] = "Unknown command: " + command_type
@@ -835,6 +863,219 @@ class AbletonMCP(ControlSurface):
         except Exception as e:
             self.log_message("Error duplicating clip to arrangement: " + str(e))
             raise
+
+
+    # ── Optimization: batch duplicate, safe deletes, lean reads ────────────────
+    # ponytail: guardrail (confirm) lives in the MCP server. These handlers only
+    # execute; delete handlers accept dry_run to power the two-phase preview.
+
+    def _resolve_slot(self, track_index, clip_index):
+        if track_index < 0 or track_index >= len(self._song.tracks):
+            raise IndexError("Track index out of range")
+        track = self._song.tracks[track_index]
+        if clip_index < 0 or clip_index >= len(track.clip_slots):
+            raise IndexError("Clip slot index out of range")
+        return track, track.clip_slots[clip_index]
+
+    def _delete_clip(self, track_index, clip_index, dry_run=False):
+        track, slot = self._resolve_slot(track_index, clip_index)
+        if not slot.has_clip:
+            raise Exception("No clip in slot " + str(clip_index) + " on track " + str(track_index))
+        info = {"track_index": track_index, "track_name": track.name,
+                "clip_index": clip_index, "clip_name": slot.clip.name}
+        if dry_run:
+            info["dry_run"] = True
+            return info
+        slot.delete_clip()
+        info["deleted"] = True
+        return info
+
+    def _clear_clip_notes(self, track_index, clip_index, dry_run=False):
+        track, slot = self._resolve_slot(track_index, clip_index)
+        if not slot.has_clip:
+            raise Exception("No clip in slot " + str(clip_index) + " on track " + str(track_index))
+        clip = slot.clip
+        if not clip.is_midi_clip:
+            raise Exception("Clip is not a MIDI clip")
+        count = len(clip.get_notes_extended(0, 128, 0.0, clip.length))
+        info = {"track_index": track_index, "clip_index": clip_index,
+                "clip_name": clip.name, "note_count": count}
+        if dry_run:
+            info["dry_run"] = True
+            return info
+        clip.remove_notes_extended(0, 128, 0.0, clip.length)
+        info["cleared"] = True
+        return info
+
+    def _delete_track(self, track_index, dry_run=False):
+        if track_index < 0 or track_index >= len(self._song.tracks):
+            raise IndexError("Track index out of range")
+        track = self._song.tracks[track_index]
+        info = {"track_index": track_index, "track_name": track.name,
+                "session_clips": sum(1 for s in track.clip_slots if s.has_clip),
+                "devices": [d.name for d in track.devices]}
+        if dry_run:
+            info["dry_run"] = True
+            return info
+        self._song.delete_track(track_index)
+        info["deleted"] = True
+        return info
+
+    def _delete_arrangement_clips(self, track_index, start_time, end_time, dry_run=False):
+        if track_index < 0 or track_index >= len(self._song.tracks):
+            raise IndexError("Track index out of range")
+        track = self._song.tracks[track_index]
+        start_time = float(start_time)
+        end_time = float(end_time)
+        # overlap test: clip intersects [start_time, end_time)
+        targets = [c for c in track.arrangement_clips
+                   if c.start_time < end_time and c.end_time > start_time]
+        info = {"track_index": track_index, "track_name": track.name,
+                "match_count": len(targets),
+                "clips": [{"name": c.name, "start_time": c.start_time,
+                           "end_time": c.end_time} for c in targets]}
+        if dry_run:
+            info["dry_run"] = True
+            return info
+        # ponytail: LOM has no per-clip arrangement delete. Live's supported
+        # route is a timeline range-delete on the Song for the selected track.
+        removed = 0
+        for c in list(targets):
+            self._song.delete_clip(c) if hasattr(self._song, "delete_clip") else track.delete_clip(c)
+            removed += 1
+        info["deleted"] = removed
+        return info
+
+    def _duplicate_session_clip_to_arrangement_batch(self, track_index, clip_index,
+                                                      destination_time, count, spacing=0.0):
+        track, slot = self._resolve_slot(track_index, clip_index)
+        if not slot.has_clip:
+            raise Exception("No clip in slot " + str(clip_index) + " on track " + str(track_index))
+        clip = slot.clip
+        # ponytail: spacing<=0 means gapless — step by the clip's own length
+        step = float(spacing) if spacing and float(spacing) > 0 else clip.length
+        t = float(destination_time)
+        placed = 0
+        for _ in range(int(count)):
+            track.duplicate_clip_to_arrangement(clip, t)
+            t += step
+            placed += 1
+        return {"track_index": track_index, "track_name": track.name,
+                "clip_name": clip.name, "placed": placed, "spacing": step,
+                "start": float(destination_time), "end": t}
+
+    def _get_notes_from_clip(self, track_index, clip_index):
+        track, slot = self._resolve_slot(track_index, clip_index)
+        if not slot.has_clip:
+            raise Exception("No clip in slot " + str(clip_index) + " on track " + str(track_index))
+        clip = slot.clip
+        if not clip.is_midi_clip:
+            raise Exception("Clip is not a MIDI clip")
+        notes = []
+        for n in clip.get_notes_extended(0, 128, 0.0, clip.length):
+            notes.append({"pitch": n.pitch, "start": n.start_time, "duration": n.duration,
+                          "velocity": n.velocity, "mute": n.mute})
+        return {"track_index": track_index, "clip_index": clip_index, "clip_name": clip.name,
+                "length": clip.length, "note_count": len(notes), "notes": notes}
+
+    def _get_tracks_overview(self):
+        tracks = []
+        for i, t in enumerate(self._song.tracks):
+            ttype = "audio" if t.has_audio_input else ("midi" if t.has_midi_input else "other")
+            tracks.append({"index": i, "name": t.name, "type": ttype,
+                           "clips": sum(1 for s in t.clip_slots if s.has_clip),
+                           "devices": len(t.devices),
+                           "mute": t.mute, "solo": t.solo, "arm": t.arm})
+        return {"tempo": self._song.tempo, "track_count": len(tracks), "tracks": tracks}
+
+
+
+
+    # ── New (round 2): combined creation, sync check, volume-API probe ─────────
+    def _create_instrument_track(self, name, uri, clip_length, notes, clip_name=None, index=-1):
+        # ponytail: collapse 5 calls (create+name+load+clip+notes) into one round trip
+        self._song.create_midi_track(-1 if (index is None or index == -1) else index)
+        ti = len(self._song.tracks) - 1 if (index is None or index == -1) else index
+        track = self._song.tracks[ti]
+        track.name = name
+        if uri:
+            self._load_browser_item(ti, uri)
+        slot = track.clip_slots[0]
+        if slot.has_clip:
+            raise Exception("Clip slot 0 already has a clip on track " + str(ti))
+        slot.create_clip(float(clip_length))
+        clip = slot.clip
+        if clip_name:
+            clip.name = clip_name
+        if notes:
+            self._add_notes_to_clip(ti, 0, notes)
+        return {"track_index": ti, "track_name": track.name, "clip_name": clip.name,
+                "note_count": len(notes or []), "devices": [d.name for d in track.devices]}
+
+    def _check_arrangement_sync(self, bar_beats=4.0):
+        bar = float(bar_beats); tol = 1e-4
+        off_grid = 0; overlaps = 0; gaps = 0; total = 0; tracks = 0; problems = []
+        for i, tr in enumerate(self._song.tracks):
+            clips = sorted(list(tr.arrangement_clips), key=lambda c: c.start_time)
+            if not clips:
+                continue
+            tracks += 1; prev_end = None
+            for c in clips:
+                total += 1
+                ratio = c.start_time / bar
+                if abs(ratio - round(ratio)) > tol:
+                    off_grid += 1
+                    problems.append({"track": tr.name, "clip": c.name, "start": c.start_time, "issue": "off_grid"})
+                if prev_end is not None:
+                    d = c.start_time - prev_end
+                    if d > tol:
+                        gaps += 1
+                    elif d < -tol:
+                        overlaps += 1
+                        problems.append({"track": tr.name, "clip": c.name, "start": c.start_time, "issue": "overlap"})
+                prev_end = c.end_time
+        return {"bar_beats": bar, "tracks_with_clips": tracks, "total_clips": total,
+                "off_grid": off_grid, "overlaps": overlaps, "gaps": gaps,
+                "in_sync": (off_grid == 0 and overlaps == 0), "problems": problems[:20]}
+
+
+
+    # ── New (round 3): arrangement volume control ─────────────────────────────
+    def _set_track_volume(self, track_index, value):
+        if track_index < 0 or track_index >= len(self._song.tracks):
+            raise IndexError("Track index out of range")
+        tr = self._song.tracks[track_index]
+        v = max(0.0, min(1.0, float(value)))
+        tr.mixer_device.volume.value = v
+        return {"track_index": track_index, "track_name": tr.name,
+                "volume": tr.mixer_device.volume.value}
+
+    def _create_volume_fade(self, track_index, clip_index, from_value, to_value, start_time=None, end_time=None, dry_run=False):
+        # Volume automation via Live API only works on SESSION clips; the fade
+        # rides into the arrangement when the clip is duplicated there.
+        if track_index < 0 or track_index >= len(self._song.tracks):
+            raise IndexError("Track index out of range")
+        tr = self._song.tracks[track_index]
+        vol = tr.mixer_device.volume
+        slot = tr.clip_slots[clip_index]
+        if not slot.has_clip:
+            raise Exception("No clip in session slot " + str(clip_index) + " on track " + str(track_index))
+        clip = slot.clip
+        length = clip.length
+        s = 0.0 if start_time is None else float(start_time)
+        e = length if end_time is None else float(end_time)
+        fv = max(0.0, min(1.0, float(from_value)))
+        tv = max(0.0, min(1.0, float(to_value)))
+        env = clip.automation_envelope(vol)
+        if env is None:
+            env = clip.create_automation_envelope(vol)
+        if dry_run:
+            return {"track_index": track_index, "clip_index": clip_index, "clip_length": length,
+                    "env_methods": sorted([n for n in dir(env) if not n.startswith("__")]) if env else None}
+        env.insert_step(s, 0.0, fv)
+        env.insert_step(e, 0.0, tv)
+        return {"track_index": track_index, "clip_index": clip_index, "clip_name": clip.name,
+                "fade": [s, e, fv, tv]}
 
     # ── Browser implementations ───────────────────────────────────────────────
 

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -117,14 +117,18 @@ class AbletonConnection:
             "start_playback", "stop_playback", "load_instrument_or_effect",
             # Arrangement view commands
             "switch_to_arrangement_view", "set_current_song_time",
-            "duplicate_session_clip_to_arrangement"
+            "duplicate_session_clip_to_arrangement",
+            "delete_clip", "clear_clip_notes", "delete_track", "delete_arrangement_clips",
+            "duplicate_session_clip_to_arrangement_batch",
+            "create_instrument_track",
+            "set_track_volume", "create_volume_fade"
         ]
 
         # Commands whose work on Live's main thread can take noticeably longer
         # than the default modifying-command budget (e.g. importing/decoding a
         # large audio file). Give them a wider socket timeout so we don't time
         # out before the Remote Script's own queue does.
-        long_running_commands = {"create_audio_clip": 65.0}
+        long_running_commands = {"create_audio_clip": 65.0, "duplicate_session_clip_to_arrangement_batch": 65.0, "create_instrument_track": 65.0}
         
         try:
             logger.info(f"Sending command: {command_type} with params: {params}")
@@ -270,47 +274,44 @@ def get_ableton_connection():
 
 @mcp.tool()
 @telemetry_tool("get_session_info")
-def get_session_info(ctx: Context, user_prompt: str = "") -> str:
+def get_session_info(ctx: Context) -> str:
     """Get detailed information about the current Ableton session
 
     Parameters:
-    - user_prompt: The original user prompt that led to this tool call (for telemetry)
     """
     try:
         ableton = get_ableton_connection()
         result = ableton.send_command("get_session_info")
-        return json.dumps(result, indent=2)
+        return json.dumps(result, separators=(",", ":"))
     except Exception as e:
         logger.error(f"Error getting session info from Ableton: {str(e)}")
         return f"Error getting session info: {str(e)}"
 
 @mcp.tool()
 @telemetry_tool("get_track_info")
-def get_track_info(ctx: Context, track_index: int, user_prompt: str = "") -> str:
+def get_track_info(ctx: Context, track_index: int) -> str:
     """
     Get detailed information about a specific track in Ableton.
 
     Parameters:
     - track_index: The index of the track to get information about
-    - user_prompt: The original user prompt that led to this tool call (for telemetry)
     """
     try:
         ableton = get_ableton_connection()
         result = ableton.send_command("get_track_info", {"track_index": track_index})
-        return json.dumps(result, indent=2)
+        return json.dumps(result, separators=(",", ":"))
     except Exception as e:
         logger.error(f"Error getting track info from Ableton: {str(e)}")
         return f"Error getting track info: {str(e)}"
 
 @mcp.tool()
 @telemetry_tool("create_midi_track")
-def create_midi_track(ctx: Context, index: int = -1, user_prompt: str = "") -> str:
+def create_midi_track(ctx: Context, index: int = -1) -> str:
     """
     Create a new MIDI track in the Ableton session.
 
     Parameters:
     - index: The index to insert the track at (-1 = end of list)
-    - user_prompt: The original user prompt that led to this tool call (for telemetry)
     """
     try:
         ableton = get_ableton_connection()
@@ -323,14 +324,13 @@ def create_midi_track(ctx: Context, index: int = -1, user_prompt: str = "") -> s
 
 @mcp.tool()
 @rich_telemetry_tool("set_track_name")
-def set_track_name(ctx: Context, track_index: int, name: str, user_prompt: str = "") -> str:
+def set_track_name(ctx: Context, track_index: int, name: str) -> str:
     """
     Set the name of a track.
 
     Parameters:
     - track_index: The index of the track to rename
     - name: The new name for the track
-    - user_prompt: The original user prompt that led to this tool call (for telemetry)
     """
     try:
         ableton = get_ableton_connection()
@@ -342,7 +342,7 @@ def set_track_name(ctx: Context, track_index: int, name: str, user_prompt: str =
 
 @mcp.tool()
 @rich_telemetry_tool("create_clip")
-def create_clip(ctx: Context, track_index: int, clip_index: int, length: float = 4.0, user_prompt: str = "") -> str:
+def create_clip(ctx: Context, track_index: int, clip_index: int, length: float = 4.0) -> str:
     """
     Create a new MIDI clip in the specified track and clip slot.
 
@@ -350,7 +350,6 @@ def create_clip(ctx: Context, track_index: int, clip_index: int, length: float =
     - track_index: The index of the track to create the clip in
     - clip_index: The index of the clip slot to create the clip in
     - length: The length of the clip in beats (default: 4.0)
-    - user_prompt: The original user prompt that led to this tool call (for telemetry)
     """
     try:
         ableton = get_ableton_connection()
@@ -366,7 +365,7 @@ def create_clip(ctx: Context, track_index: int, clip_index: int, length: float =
 
 @mcp.tool()
 @rich_telemetry_tool("create_audio_clip")
-def create_audio_clip(ctx: Context, track_index: int, clip_index: int, path: str, user_prompt: str = "") -> str:
+def create_audio_clip(ctx: Context, track_index: int, clip_index: int, path: str) -> str:
     """
     Create a new audio clip in an audio track's clip slot by importing a file.
 
@@ -379,7 +378,6 @@ def create_audio_clip(ctx: Context, track_index: int, clip_index: int, path: str
     - clip_index: The index of the clip slot to create the clip in
     - path: Absolute path to a supported audio file (e.g. a .wav). The target
       track must be an audio track and the clip slot must be empty.
-    - user_prompt: The original user prompt that led to this tool call (for telemetry)
     """
     try:
         ableton = get_ableton_connection()
@@ -399,8 +397,7 @@ def add_notes_to_clip(
     ctx: Context,
     track_index: int,
     clip_index: int,
-    notes: List[Dict[str, Union[int, float, bool]]],
-    user_prompt: str = ""
+    notes: List[Dict[str, Union[int, float, bool]]]
 ) -> str:
     """
     Add MIDI notes to a clip.
@@ -409,7 +406,6 @@ def add_notes_to_clip(
     - track_index: The index of the track containing the clip
     - clip_index: The index of the clip slot containing the clip
     - notes: List of note dictionaries, each with pitch, start_time, duration, velocity, and mute
-    - user_prompt: The original user prompt that led to this tool call (for telemetry)
     """
     try:
         ableton = get_ableton_connection()
@@ -425,7 +421,7 @@ def add_notes_to_clip(
 
 @mcp.tool()
 @rich_telemetry_tool("set_clip_name")
-def set_clip_name(ctx: Context, track_index: int, clip_index: int, name: str, user_prompt: str = "") -> str:
+def set_clip_name(ctx: Context, track_index: int, clip_index: int, name: str) -> str:
     """
     Set the name of a clip.
 
@@ -433,7 +429,6 @@ def set_clip_name(ctx: Context, track_index: int, clip_index: int, name: str, us
     - track_index: The index of the track containing the clip
     - clip_index: The index of the clip slot containing the clip
     - name: The new name for the clip
-    - user_prompt: The original user prompt that led to this tool call (for telemetry)
     """
     try:
         ableton = get_ableton_connection()
@@ -449,13 +444,12 @@ def set_clip_name(ctx: Context, track_index: int, clip_index: int, name: str, us
 
 @mcp.tool()
 @rich_telemetry_tool("set_tempo")
-def set_tempo(ctx: Context, tempo: float, user_prompt: str = "") -> str:
+def set_tempo(ctx: Context, tempo: float) -> str:
     """
     Set the tempo of the Ableton session.
 
     Parameters:
     - tempo: The new tempo in BPM
-    - user_prompt: The original user prompt that led to this tool call (for telemetry)
     """
     try:
         ableton = get_ableton_connection()
@@ -468,14 +462,13 @@ def set_tempo(ctx: Context, tempo: float, user_prompt: str = "") -> str:
 
 @mcp.tool()
 @rich_telemetry_tool("load_instrument_or_effect")
-def load_instrument_or_effect(ctx: Context, track_index: int, uri: str, user_prompt: str = "") -> str:
+def load_instrument_or_effect(ctx: Context, track_index: int, uri: str) -> str:
     """
     Load an instrument or effect onto a track using its URI.
 
     Parameters:
     - track_index: The index of the track to load the instrument on
     - uri: The URI of the instrument or effect to load (e.g., 'query:Synths#Instrument%20Rack:Bass:FileId_5116')
-    - user_prompt: The original user prompt that led to this tool call (for telemetry)
     """
     try:
         ableton = get_ableton_connection()
@@ -500,14 +493,13 @@ def load_instrument_or_effect(ctx: Context, track_index: int, uri: str, user_pro
 
 @mcp.tool()
 @telemetry_tool("fire_clip")
-def fire_clip(ctx: Context, track_index: int, clip_index: int, user_prompt: str = "") -> str:
+def fire_clip(ctx: Context, track_index: int, clip_index: int) -> str:
     """
     Start playing a clip.
 
     Parameters:
     - track_index: The index of the track containing the clip
     - clip_index: The index of the clip slot containing the clip
-    - user_prompt: The original user prompt that led to this tool call (for telemetry)
     """
     try:
         ableton = get_ableton_connection()
@@ -522,14 +514,13 @@ def fire_clip(ctx: Context, track_index: int, clip_index: int, user_prompt: str 
 
 @mcp.tool()
 @telemetry_tool("stop_clip")
-def stop_clip(ctx: Context, track_index: int, clip_index: int, user_prompt: str = "") -> str:
+def stop_clip(ctx: Context, track_index: int, clip_index: int) -> str:
     """
     Stop playing a clip.
 
     Parameters:
     - track_index: The index of the track containing the clip
     - clip_index: The index of the clip slot containing the clip
-    - user_prompt: The original user prompt that led to this tool call (for telemetry)
     """
     try:
         ableton = get_ableton_connection()
@@ -544,11 +535,10 @@ def stop_clip(ctx: Context, track_index: int, clip_index: int, user_prompt: str 
 
 @mcp.tool()
 @telemetry_tool("start_playback")
-def start_playback(ctx: Context, user_prompt: str = "") -> str:
+def start_playback(ctx: Context) -> str:
     """Start playing the Ableton session.
 
     Parameters:
-    - user_prompt: The original user prompt that led to this tool call (for telemetry)
     """
     try:
         ableton = get_ableton_connection()
@@ -560,11 +550,10 @@ def start_playback(ctx: Context, user_prompt: str = "") -> str:
 
 @mcp.tool()
 @telemetry_tool("stop_playback")
-def stop_playback(ctx: Context, user_prompt: str = "") -> str:
+def stop_playback(ctx: Context) -> str:
     """Stop playing the Ableton session.
 
     Parameters:
-    - user_prompt: The original user prompt that led to this tool call (for telemetry)
     """
     try:
         ableton = get_ableton_connection()
@@ -576,13 +565,12 @@ def stop_playback(ctx: Context, user_prompt: str = "") -> str:
 
 @mcp.tool()
 @rich_telemetry_tool("get_browser_tree")
-def get_browser_tree(ctx: Context, category_type: str = "all", user_prompt: str = "") -> str:
+def get_browser_tree(ctx: Context, category_type: str = "all") -> str:
     """
     Get a hierarchical tree of browser categories from Ableton.
 
     Parameters:
     - category_type: Type of categories to get ('all', 'instruments', 'sounds', 'drums', 'audio_effects', 'midi_effects')
-    - user_prompt: The original user prompt that led to this tool call (for telemetry)
     """
     try:
         ableton = get_ableton_connection()
@@ -641,14 +629,13 @@ def get_browser_tree(ctx: Context, category_type: str = "all", user_prompt: str 
 
 @mcp.tool()
 @rich_telemetry_tool("get_browser_items_at_path")
-def get_browser_items_at_path(ctx: Context, path: str, user_prompt: str = "") -> str:
+def get_browser_items_at_path(ctx: Context, path: str) -> str:
     """
     Get browser items at a specific path in Ableton's browser.
 
     Parameters:
     - path: Path in the format "category/folder/subfolder"
             where category is one of the available browser categories in Ableton
-    - user_prompt: The original user prompt that led to this tool call (for telemetry)
     """
     try:
         ableton = get_ableton_connection()
@@ -663,7 +650,7 @@ def get_browser_items_at_path(ctx: Context, path: str, user_prompt: str = "") ->
             return (f"Error: {error}\n"
                    f"Available browser categories: {', '.join(available_cats)}")
         
-        return json.dumps(result, indent=2)
+        return json.dumps(result, separators=(",", ":"))
     except Exception as e:
         error_msg = str(e)
         if "Browser is not available" in error_msg:
@@ -684,7 +671,7 @@ def get_browser_items_at_path(ctx: Context, path: str, user_prompt: str = "") ->
 
 @mcp.tool()
 @rich_telemetry_tool("load_drum_kit")
-def load_drum_kit(ctx: Context, track_index: int, rack_uri: str, kit_path: str, user_prompt: str = "") -> str:
+def load_drum_kit(ctx: Context, track_index: int, rack_uri: str, kit_path: str) -> str:
     """
     Load a drum rack and then load a specific drum kit into it.
 
@@ -692,7 +679,6 @@ def load_drum_kit(ctx: Context, track_index: int, rack_uri: str, kit_path: str, 
     - track_index: The index of the track to load on
     - rack_uri: The URI of the drum rack to load (e.g., 'Drums/Drum Rack')
     - kit_path: Path to the drum kit inside the browser (e.g., 'drums/acoustic/kit1')
-    - user_prompt: The original user prompt that led to this tool call (for telemetry)
     """
     try:
         ableton = get_ableton_connection()
@@ -737,11 +723,10 @@ def load_drum_kit(ctx: Context, track_index: int, rack_uri: str, kit_path: str, 
 
 @mcp.tool()
 @telemetry_tool("switch_to_arrangement_view")
-def switch_to_arrangement_view(ctx: Context, user_prompt: str = "") -> str:
+def switch_to_arrangement_view(ctx: Context) -> str:
     """Switch Ableton's main window to the Arrangement view.
 
     Parameters:
-    - user_prompt: The original user prompt that led to this tool call (for telemetry)
     """
     try:
         ableton = get_ableton_connection()
@@ -754,13 +739,12 @@ def switch_to_arrangement_view(ctx: Context, user_prompt: str = "") -> str:
 
 @mcp.tool()
 @rich_telemetry_tool("set_arrangement_time")
-def set_arrangement_time(ctx: Context, time: float, user_prompt: str = "") -> str:
+def set_arrangement_time(ctx: Context, time: float) -> str:
     """
     Move the arrangement playhead to a specific position.
 
     Parameters:
     - time: Position in beats from the start of the arrangement (e.g. 8.0 = bar 3 in 4/4)
-    - user_prompt: The original user prompt that led to this tool call (for telemetry)
     """
     try:
         ableton = get_ableton_connection()
@@ -773,7 +757,7 @@ def set_arrangement_time(ctx: Context, time: float, user_prompt: str = "") -> st
 
 @mcp.tool()
 @telemetry_tool("get_arrangement_clips")
-def get_arrangement_clips(ctx: Context, track_index: int, user_prompt: str = "") -> str:
+def get_arrangement_clips(ctx: Context, track_index: int) -> str:
     """
     List all clips placed in the Arrangement timeline for a track.
 
@@ -781,12 +765,11 @@ def get_arrangement_clips(ctx: Context, track_index: int, user_prompt: str = "")
 
     Parameters:
     - track_index: The index of the track to inspect
-    - user_prompt: The original user prompt that led to this tool call (for telemetry)
     """
     try:
         ableton = get_ableton_connection()
         result = ableton.send_command("get_arrangement_clips", {"track_index": track_index})
-        return json.dumps(result, indent=2)
+        return json.dumps(result, separators=(",", ":"))
     except Exception as e:
         logger.error(f"Error getting arrangement clips: {str(e)}")
         return f"Error getting arrangement clips: {str(e)}"
@@ -798,8 +781,7 @@ def duplicate_to_arrangement(
     ctx: Context,
     track_index: int,
     clip_index: int,
-    destination_time: float,
-    user_prompt: str = ""
+    destination_time: float
 ) -> str:
     """
     Copy a Session-view clip into the Arrangement timeline.
@@ -818,7 +800,6 @@ def duplicate_to_arrangement(
     - clip_index:        Index of the clip slot in that track (Session view)
     - destination_time:  Beat position in the arrangement to place the clip
                          (e.g. 0.0 = start, 8.0 = bar 3 in 4/4)
-    - user_prompt: The original user prompt that led to this tool call (for telemetry)
     """
     try:
         ableton = get_ableton_connection()
@@ -839,6 +820,244 @@ def duplicate_to_arrangement(
     except Exception as e:
         logger.error(f"Error duplicating clip to arrangement: {str(e)}")
         return f"Error duplicating clip to arrangement: {str(e)}"
+
+
+# ── Optimization tools: batch duplicate, guarded deletes, lean reads ──────────
+# ponytail: one helper for the two-phase delete guardrail instead of repeating
+# the confirm/preview dance in every delete tool. Without confirm=True nothing
+# is deleted — the Remote Script returns a dry-run preview the human approves.
+
+def _guarded_delete(delete_cmd: str, params: dict, confirm: bool, what: str) -> str:
+    ableton = get_ableton_connection()
+    if not confirm:
+        preview = ableton.send_command(delete_cmd, dict(params, dry_run=True))
+        return ("CONFIRM REQUIRED - nothing changed yet. Would affect " + what + ": "
+                + json.dumps(preview, separators=(",", ":"))
+                + " | Re-call this tool with confirm=true to proceed.")
+    result = ableton.send_command(delete_cmd, dict(params, dry_run=False))
+    return "Done. " + json.dumps(result, separators=(",", ":"))
+
+
+@mcp.tool()
+def delete_clip(ctx: Context, track_index: int, clip_index: int, confirm: bool = False) -> str:
+    """Delete a Session-view clip from its slot. SAFE: call once to preview, then again with confirm=true to delete.
+
+    Parameters:
+    - track_index: index of the track
+    - clip_index: index of the clip slot
+    - confirm: must be true to actually delete (default false = preview only)
+    """
+    try:
+        return _guarded_delete("delete_clip",
+                               {"track_index": track_index, "clip_index": clip_index},
+                               confirm, "clip at track " + str(track_index) + " slot " + str(clip_index))
+    except Exception as e:
+        logger.error(f"Error deleting clip: {str(e)}")
+        return f"Error deleting clip: {str(e)}"
+
+
+@mcp.tool()
+def clear_clip_notes(ctx: Context, track_index: int, clip_index: int, confirm: bool = False) -> str:
+    """Erase all MIDI notes from a clip but keep the clip. SAFE: call once to preview, then confirm=true to clear.
+
+    Parameters:
+    - track_index: index of the track
+    - clip_index: index of the clip slot
+    - confirm: must be true to actually clear (default false = preview only)
+    """
+    try:
+        return _guarded_delete("clear_clip_notes",
+                               {"track_index": track_index, "clip_index": clip_index},
+                               confirm, "notes in clip at track " + str(track_index) + " slot " + str(clip_index))
+    except Exception as e:
+        logger.error(f"Error clearing clip notes: {str(e)}")
+        return f"Error clearing clip notes: {str(e)}"
+
+
+@mcp.tool()
+def delete_arrangement_clips(ctx: Context, track_index: int, start_time: float,
+                             end_time: float, confirm: bool = False) -> str:
+    """Delete Arrangement clips on a track that overlap a beat range. SAFE: preview first, then confirm=true.
+
+    Parameters:
+    - track_index: index of the track
+    - start_time: range start in beats
+    - end_time: range end in beats
+    - confirm: must be true to actually delete (default false = preview only)
+    """
+    try:
+        return _guarded_delete("delete_arrangement_clips",
+                               {"track_index": track_index, "start_time": start_time, "end_time": end_time},
+                               confirm, "arrangement clips on track " + str(track_index)
+                               + " in beats " + str(start_time) + "-" + str(end_time))
+    except Exception as e:
+        logger.error(f"Error deleting arrangement clips: {str(e)}")
+        return f"Error deleting arrangement clips: {str(e)}"
+
+
+@mcp.tool()
+def delete_track(ctx: Context, track_index: int, confirm: bool = False) -> str:
+    """Delete an entire track and everything on it. SAFE + destructive: preview first, then confirm=true.
+
+    Parameters:
+    - track_index: index of the track to delete
+    - confirm: must be true to actually delete (default false = preview only)
+    """
+    try:
+        return _guarded_delete("delete_track", {"track_index": track_index},
+                               confirm, "track " + str(track_index) + " (and all its clips/devices)")
+    except Exception as e:
+        logger.error(f"Error deleting track: {str(e)}")
+        return f"Error deleting track: {str(e)}"
+
+
+@mcp.tool()
+def duplicate_to_arrangement_batch(ctx: Context, track_index: int, clip_index: int,
+                                   destination_time: float, count: int, spacing: float = 0.0) -> str:
+    """Place COUNT copies of a Session clip into the Arrangement in ONE call (no per-copy round trips).
+
+    Parameters:
+    - track_index: index of the track owning the Session clip
+    - clip_index: index of the clip slot
+    - destination_time: beat position of the first copy
+    - count: how many copies to place
+    - spacing: beats between copy starts; 0 (default) = back-to-back using the clip's own length
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("duplicate_session_clip_to_arrangement_batch", {
+            "track_index": track_index, "clip_index": clip_index,
+            "destination_time": destination_time, "count": count, "spacing": spacing})
+        return ("Placed " + str(result.get("placed", count)) + " copies of '"
+                + str(result.get("clip_name", "clip")) + "' on '"
+                + str(result.get("track_name", track_index)) + "' from beat "
+                + str(destination_time) + " (spacing " + str(result.get("spacing")) + ").")
+    except Exception as e:
+        logger.error(f"Error batch-duplicating to arrangement: {str(e)}")
+        return f"Error batch-duplicating to arrangement: {str(e)}"
+
+
+@mcp.tool()
+def get_notes_from_clip(ctx: Context, track_index: int, clip_index: int) -> str:
+    """Read the MIDI notes already in a clip so you can edit precisely instead of guessing. Compact JSON.
+
+    Parameters:
+    - track_index: index of the track
+    - clip_index: index of the clip slot
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("get_notes_from_clip",
+                                      {"track_index": track_index, "clip_index": clip_index})
+        return json.dumps(result, separators=(",", ":"))
+    except Exception as e:
+        logger.error(f"Error reading notes from clip: {str(e)}")
+        return f"Error reading notes from clip: {str(e)}"
+
+
+@mcp.tool()
+def get_tracks_overview(ctx: Context) -> str:
+    """Compact list of ALL tracks (index, name, type, clip count, device count) in one call.
+
+    Use this to orient before drilling into a single track with get_track_info.
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("get_tracks_overview")
+        return json.dumps(result, separators=(",", ":"))
+    except Exception as e:
+        logger.error(f"Error getting tracks overview: {str(e)}")
+        return f"Error getting tracks overview: {str(e)}"
+
+
+
+
+
+@mcp.tool()
+def create_instrument_track(ctx: Context, name: str, uri: str, clip_length: float = 4.0,
+                            notes: List[Dict[str, Union[int, float, bool]]] = None,
+                            clip_name: str = "") -> str:
+    """Create a MIDI track, name it, load an instrument by URI, make a clip and add notes in ONE call.
+
+    Collapses create_midi_track + set_track_name + load_instrument_or_effect + create_clip + add_notes_to_clip.
+
+    Parameters:
+    - name: track name
+    - uri: instrument/preset browser URI to load
+    - clip_length: clip length in beats
+    - notes: list of note dicts (pitch, start_time, duration, velocity, mute); optional
+    - clip_name: optional name for the created clip
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("create_instrument_track", {
+            "name": name, "uri": uri, "clip_length": clip_length,
+            "notes": notes or [], "clip_name": clip_name})
+        return "Created instrument track '%s' (index %s) with %s notes." % (
+            result.get("track_name", name), result.get("track_index"), result.get("note_count"))
+    except Exception as e:
+        logger.error(f"Error creating instrument track: {str(e)}")
+        return f"Error creating instrument track: {str(e)}"
+
+
+@mcp.tool()
+def check_arrangement_sync(ctx: Context, bar_beats: float = 4.0) -> str:
+    """Check that arrangement clips across all tracks are grid-aligned and free of gaps/overlaps. Compact JSON.
+
+    Parameters:
+    - bar_beats: beats per bar (default 4.0)
+    """
+    try:
+        ableton = get_ableton_connection()
+        return json.dumps(ableton.send_command("check_arrangement_sync", {"bar_beats": bar_beats}), separators=(",", ":"))
+    except Exception as e:
+        logger.error(f"Error checking arrangement sync: {str(e)}")
+        return f"Error checking arrangement sync: {str(e)}"
+
+
+
+
+
+@mcp.tool()
+def set_track_volume(ctx: Context, track_index: int, value: float) -> str:
+    """Set a track's mixer volume immediately (0.0-1.0). Use for static section mix balance.
+
+    Parameters:
+    - track_index: index of the track
+    - value: volume 0.0 (silence) to 1.0 (unity ~0 dB region)
+    """
+    try:
+        ableton = get_ableton_connection()
+        r = ableton.send_command("set_track_volume", {"track_index": track_index, "value": value})
+        return "Set '%s' volume to %s" % (r.get("track_name", track_index), r.get("volume"))
+    except Exception as e:
+        logger.error(f"Error setting track volume: {str(e)}")
+        return f"Error setting track volume: {str(e)}"
+
+
+@mcp.tool()
+def create_volume_fade(ctx: Context, track_index: int, clip_index: int,
+                       from_value: float, to_value: float) -> str:
+    """Write a volume fade across a Session clip (it carries into the arrangement when duplicated).
+
+    Use long section clips for section-length entrances/exits (fade in an intro, fade out an outro).
+
+    Parameters:
+    - track_index: index of the track
+    - clip_index: session clip slot index that holds the clip
+    - from_value: starting volume 0.0-1.0
+    - to_value: ending volume 0.0-1.0
+    """
+    try:
+        ableton = get_ableton_connection()
+        r = ableton.send_command("create_volume_fade", {
+            "track_index": track_index, "clip_index": clip_index,
+            "from_value": from_value, "to_value": to_value})
+        return "Volume fade on '%s' clip %s (%s->%s)." % (r.get("clip_name", track_index), clip_index, from_value, to_value)
+    except Exception as e:
+        logger.error(f"Error creating volume fade: {str(e)}")
+        return f"Error creating volume fade: {str(e)}"
+
 
 
 # Main execution

--- a/README.md
+++ b/README.md
@@ -134,6 +134,19 @@ Once the config file has been set on Claude, and the remote script is running in
 - Add notes to MIDI clips
 - Change tempo and other session parameters
 
+## Optimized tools (v1.2.1)
+
+This build adds token-efficient and higher-level tools:
+
+- **Batch arrangement**: `duplicate_to_arrangement_batch` places N copies in one call.
+- **One-call instrument**: `create_instrument_track` creates a track, names it, loads an instrument, makes a clip and adds notes in a single call.
+- **Lean reads**: `get_tracks_overview` (compact all-track summary) and `get_notes_from_clip`.
+- **Guarded deletes** (two-phase confirm): `delete_clip`, `clear_clip_notes`, `delete_arrangement_clips`, `delete_track`. Without `confirm=true` they return a preview and change nothing.
+- **Mix & automation**: `set_track_volume` and `create_volume_fade` (volume automation on a Session clip that carries into the arrangement).
+- **Sync check**: `check_arrangement_sync` reports grid alignment (off-grid, overlaps, gaps).
+
+The `user_prompt` telemetry parameter was removed from all tools and read outputs use compact JSON, cutting token usage substantially.
+
 ## Example Commands
 
 Here are some examples of what you can ask Claude to do:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ableton-mcp"
-version = "1.2.0"
+version = "1.2.1"
 description = "Ableton Live integration through the Model Context Protocol"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
# PR: Token-efficient AbletonMCP (batch ops, guarded deletes, combined creation, volume + sync)

## Summary
Reduces LLM token use and round trips, and adds capability, without changing the socket protocol style. Verified live on Ableton Live 12.4.2. On a full 3 minute arrangement the command count drops 91% (354 to 31), exact tokens drop 80% (33,521 to 6,804), and build time drops 89% (262s to 29s), while the optimized path also does volume automation and a sync check that the old path cannot.

## What changed
Server exposes 32 tools (was 21). 11 new tools, plus a token diet on the existing ones.

New tools:
- `duplicate_to_arrangement_batch(track, clip, destination_time, count, spacing)`: place N copies in one call (spacing 0 = gapless).
- `create_instrument_track(name, uri, clip_length, notes, clip_name)`: create track + name + load instrument + clip + notes in one call.
- `get_tracks_overview()`: compact list of all tracks (one call vs N verbose get_track_info).
- `get_notes_from_clip(track, clip)`: read existing MIDI notes so edits are not guesses.
- `delete_clip`, `clear_clip_notes`, `delete_arrangement_clips`, `delete_track`: destructive ops with a two phase confirm guardrail (a call without `confirm=true` returns a preview and changes nothing).
- `set_track_volume(track, value)`: static mixer volume.
- `create_volume_fade(track, clip_index, from_value, to_value)`: volume automation fade on a Session clip (rides into the arrangement when duplicated). The Live API only allows automation on Session clips, so fades are authored there.
- `check_arrangement_sync(bar_beats)`: compact grid alignment report (off_grid, overlaps, gaps counts plus only the problem clips).

Token diet on existing tools:
- Removed the `user_prompt` parameter from all 21 original tools (42 sites). It forced the model to resend the whole prompt on every call.
- Compact JSON on the 4 read tools (`indent=2` to separators).

## Guardrail
Deletes use a two phase confirm because an MCP call cannot pause for human input mid call. Without `confirm=true` the tool runs a dry run and returns exactly what would be removed; the human approves and re calls with `confirm=true`.

## Breaking / behavior notes for the maintainer
- Removing `user_prompt` disables prompt based telemetry. The decorator degrades to `None`, so nothing breaks, but if you want to keep prompt telemetry, make it an opt in env var instead.
- Live API constraints: `create_audio_clip` needs Live 12.0.5+, arrangement volume automation is authored on Session clips (documented in the tool).
- Version bumped to 1.2.1.

## Files
- `MCP_Server/server.py`: see `PR_server.py.patch`
- `AbletonMCP_Remote_Script/__init__.py`: see `PR_remote_script.__init__.py.patch`

## Verification
py_compile clean, FastMCP loads 32 tools, `user_prompt` absent from every schema. All new endpoints tested live on a scratch track that was created and deleted. Full benchmark, charts and two audible demo sets in the attached report.

---

## Demo sets (download and open in Live 12)

These Ableton sets let a reviewer hear the output. They use only Live 12 factory devices (DS Kick/HH/Clap, Acid Bass, 303), so no external samples are needed.

- [techno_acid_3min_140.als](https://raw.githubusercontent.com/M4x28/ableton-mcp/pr-assets/demo/techno_acid_3min_140.als): the full 3 minute arrangement with sections, mix and fades.
- [techno_acid_optimized.als](https://raw.githubusercontent.com/M4x28/ableton-mcp/pr-assets/demo/techno_acid_optimized.als) and [techno_acid_original.als](https://raw.githubusercontent.com/M4x28/ableton-mcp/pr-assets/demo/techno_acid_original.als): the 16 bar short test, identical music built by each workflow, for an A/B listen.

These files live on the fork's `pr-assets` branch and are not part of the code diff.

---

# Appendix A: Benchmark, round 2 (exact tokens, new endpoints, 3-minute track)

## AbletonMCP Optimization, Round 2: exact tokens, new endpoints, 3-minute track

This round answers four requests: measure exact tokens (not an estimate), report a real end to end wall clock, reduce the cost of the sample creation phase, and add a long benchmark that builds a full 3 minute arrangement using two brand new endpoints. Everything below was run live against Ableton Live 12.4.2.

## Method

Tokens are counted with a real BPE tokenizer (tiktoken `o200k_base`) applied to the exact request and response strings of every call. This is an exact integer count, not a characters divided by four estimate. Claude's own tokenizer is not published for offline use, so a real tokenizer is the closest exact and reproducible measure.

Wall clock is a single real timer around the whole run, from the first call to the last, reported as measured. It covers the connector plus Ableton execution. It does not include model inference time, so a real chat session would be slower on both versions, and more so on the original because it fires far more calls.

## Two new endpoints (plus one that cuts phase 1)

| Endpoint | What it does | Live test |
|----------|--------------|-----------|
| `create_volume_fade` | Writes a volume automation fade on a Session clip that rides into the arrangement when the clip is placed. Used for intro fade in and outro fade out. | Pass, verified the envelope and `insert_step` API, fade 0.0 to 0.9 written |
| `check_arrangement_sync` | Reports whether arrangement clips are grid aligned across all tracks. Returns compact counts (off grid, overlaps, gaps) plus only the problem clips. | Pass, on the 3 minute track: 328 clips, off grid 0, overlaps 0, in sync true |
| `set_track_volume` | Sets a track mixer volume for static section balance. | Pass |
| `create_instrument_track` | Collapses create track, name, load instrument, create clip and add notes into ONE call, and names the clip. This is the phase 1 cost fix. | Pass |

The Live API only allows volume automation on Session clips, so `create_volume_fade` writes the fade there and the arrangement inherits it when the clip is duplicated. That is why the intro and outro use dedicated 8 bar section clips.

The connector fork now exposes 32 tools. All four endpoints were tested on a scratch track that was created and deleted, leaving the set unchanged.

## Short benchmark (16 bar loop), exact numbers

Same acid track built twice: five instruments (kick, acid bass, hat, clap, acid melody) then a 16 bar arrangement. Identical music, so the only difference is the connector.

| Metric | Original | Optimized | Change |
|--------|---------:|----------:|-------:|
| Tool calls | 88 | 13 | down 85 percent |
| Tokens (exact) | 8,207 | 2,023 | down 75 percent |
| Wall clock | 64.8 s | 11.9 s | down 82 percent |
| Phase 1 tokens (create samples) | 2,978 | 1,492 | down 50 percent |
| Phase 1 calls | 25 | 5 | down 80 percent |

The sample creation phase now costs half as much and does more: `create_instrument_track` builds each instrument in one call and also names its clip. So the optimized version is cheaper and better organised at the same time, which was the request.

## Long benchmark: full 3 minute acid track at 140 BPM

The long test builds a real arrangement with intro, build, drop, break, climax and outro across 104 bars (about 3:12 at 140 BPM). The optimized run also adds a static mix, an intro fade in on the kick, an outro fade out on the bass, and a final synchronization check. The original run reproduces the same notes and arrangement with the old command style (one clip placement per call, prompt echoed on every call) and cannot do the automation or the check at all.

| Metric | Original | Optimized | Change |
|--------|---------:|----------:|-------:|
| Tool calls | 354 | 31 | down 91 percent |
| Tokens (exact) | 33,521 | 6,804 | down 80 percent |
| Wall clock | 262.2 s | 29.4 s | down 89 percent |

![bench2_long_phases.png](https://raw.githubusercontent.com/M4x28/ableton-mcp/pr-assets/assets/bench2_long_phases.png)
The arrangement phase is where the gap explodes: 327 individual placements on the original become 10 batch calls on the optimized version, and the placement cost drops from about 30,100 tokens to 602. The optimized total still includes roughly 4,557 tokens of volume automation work that the original simply cannot perform, so the optimized version does more and still costs 80 percent less.

The synchronization check confirmed the result: 328 arrangement clips, zero off grid, zero overlaps, in sync true. The four gaps it reports are the intentional silences of the break and the section entries, which the endpoint lists separately rather than treating as errors.

![bench2_totals.png](https://raw.githubusercontent.com/M4x28/ableton-mcp/pr-assets/assets/bench2_totals.png)
## Deliverables

| File | What it is |
|------|-----------|
| `techno_acid_3min_140.als` | The full 3 minute arrangement with sections, mix and fades, open in Live 12 to judge the result |
| `techno_acid_optimized.als`, `techno_acid_original.als` | The 16 bar short test tracks, identical music, for an A B listen |
| `bench2_long_phases.png`, `bench2_totals.png` | The charts above |
| `short_exact.json`, `long_exact.json` | The raw exact token and timing data |

## Notes

The token figures use a real tokenizer, so treat them as exact for that tokenizer; Claude's absolute counts differ slightly but the relative reductions hold. The wall clock is the measured end to end time of each run. The four connector endpoints added this round are all verified live and shipped in the fork, which now carries 32 tools and activates on the next Claude Desktop restart.

---

# Appendix B: First benchmark (16-bar build, original vs optimized)

## AbletonMCP Benchmark - Techno Acid Track, End-to-End

Same track built twice through the **same** Ableton Live 12.4.2 + AbletonMCP socket, once with the **original v1.2.0** command style, once with the **optimized fork**. Music is byte-identical between runs (`.als` 60,336 vs 60,351 B), so any difference is purely connector efficiency.

## 1. Method

- **Two phases per run:** (1) create one instrument/sample per part, (2) build the 16-bar arrangement.
- **What differs by version:** original sends `user_prompt` on every tool call and places arrangement clips one-by-one; optimized drops `user_prompt`, uses `duplicate_to_arrangement_batch`, and uses the compact `get_tracks_overview`.
- **Metrics:** tool calls (round trips), LLM-side tokens (modeled: request args the model emits + text the server returns; `user_prompt` counted for original, `indent=2` vs compact for reads), wall-clock seconds (real, measured over the socket).
- **Token proxy:** chars ÷ 4. Relative % is near tokenizer-invariant; absolute tokens are ballpark.

## 2. The track (identical in both runs)

130 BPM, A minor. Five parts, each its own MIDI track + device + 1 Session clip, then arranged.

| Part | Device (Live factory) | Browser URI | Pattern | Arrangement |
|------|----------------------|-------------|---------|-------------|
| Kick | DS Kick | `query:Synths#DS%20Kick` | 4-on-floor, C1 | bars 1-16 (×16) |
| Bass | Acid Bass (303) | `query:Sounds#Bass:FileId_6970` | 16th-note acid line, A1 w/ octave/fifth + accents | bars 1-16 (×16) |
| Hat | DS HH | `query:Synths#DS%20HH` | offbeat 8ths + 16th ghosts | bars 5-16 (×12) |
| Clap | DS Clap | `query:Synths#DS%20Clap` | beats 2 & 4 | bars 5-16 (×12) |
| Melody | Basic 303 Bass | `query:Sounds#Bass:FileId_5239` | 2-bar A-minor pentatonic acid riff | bars 9-16 (×4) |

Structure: intro (kick+bass) → build (add hat+clap) → drop (add acid melody). 60 arrangement clips total.

## 3. Results

![bench_acid_summary.png](https://raw.githubusercontent.com/M4x28/ableton-mcp/pr-assets/assets/bench_acid_summary.png)
| Metric | Original v1.2.0 | Optimized fork | Reduction |
|--------|----------------:|---------------:|----------:|
| Tool calls (round trips) | 88 | 33 | **−62%** |
| Tokens (LLM-side) | 7,676 | 2,064 | **−73%** |
| Wall-clock time | 61.6 s | 26.3 s | **−57%** |

### Per phase

| Phase | Metric | Original | Optimized | Reduction |
|-------|--------|--------:|----------:|----------:|
| Setup (orient + tempo) | calls / tok / s | 2 / 192 / 1.3 | 2 / 143 / 1.0 | tok −26% |
| Phase 1 - create samples | calls / tok / s | 25 / 2,573 / 18.4 | 25 / 1,654 / 20.8 | tok −36% |
| Phase 2 - arrangement | calls / tok / s | 61 / 4,911 / 41.9 | 6 / 267 / 4.5 | calls −90%, tok −95%, time −89% |

![bench_acid_tokens.png](https://raw.githubusercontent.com/M4x28/ableton-mcp/pr-assets/assets/bench_acid_tokens.png)
![bench_acid_calls.png](https://raw.githubusercontent.com/M4x28/ableton-mcp/pr-assets/assets/bench_acid_calls.png)
![bench_acid_time.png](https://raw.githubusercontent.com/M4x28/ableton-mcp/pr-assets/assets/bench_acid_time.png)
**Reading it:**
- **Phase 2 is where the connector wins**: 61 individual `duplicate` calls collapse to 5 `batch` calls (+1 view switch). Tokens −95%, time −89%.
- **Phase 1 has the same call count** (5 parts × 5 steps) - the −36% token cut is 100% the removed `user_prompt` echo (~27 tok × 25 calls). Its wall-clock is instrument-load-bound, so the ~2 s difference is noise, not signal.
- Real-world gap is **larger** than the wall-clock shown: each of the 55 extra original calls is also a full LLM inference round trip (seconds) that the socket timing does not capture.

## 4. Design decisions & changes (one by one)

| # | Change | Type | Rationale | Effect in this benchmark |
|---|--------|------|-----------|--------------------------|
| 1 | Remove `user_prompt` from all 21 tools | Token diet | Original forced the model to resend the whole prompt every call; telemetry-only value; degrades to `None` cleanly | −36% Phase 1 tokens, −26% setup tokens |
| 2 | `duplicate_to_arrangement_batch(count, spacing)` | New tool | N-copy loop was 1 call/clip; `spacing=0` = gapless by clip length | Phase 2: 60 calls → 5; −95% tokens |
| 3 | `get_tracks_overview` | New tool | One compact call vs `get_session_info` + N verbose `get_track_info` to orient | Setup read compact vs verbose |
| 4 | Compact JSON (`indent=2` → separators) on 4 reads | Token diet | Indentation is pure whitespace tokens | Smaller read payloads |
| 5 | `get_notes_from_clip` | New tool | Lets the model edit existing notes instead of guessing | Not exercised here (build-only) |
| 6 | `delete_clip` / `clear_clip_notes` / `delete_arrangement_clips` / `delete_track`, two-phase `confirm` | New tools + guardrail | Deletes were impossible; MCP can't block for human input, so preview-then-`confirm=true` keeps a human in the loop | Not exercised here (build-only) |

Full connector rationale and rollback: see `AbletonMCP_optimization_casestudy.md`. Code diffs: `server.py.patch`, `remote_script.__init__.py.patch`.

## 5. Deliverables (for qualitative A/B)

- `techno_acid_original.als` - built via original workflow
- `techno_acid_optimized.als` - built via optimized workflow

Both open in Ableton Live 12 (factory devices only, no external samples). They are sonically identical by construction - open either to judge the musical result; use the metrics above to judge the connector.

## 6. Caveats

- Token counts are a chars/4 proxy, not the exact Anthropic tokenizer - trust the %, not the absolute.
- Wall-clock measured over the socket (Ableton execution + transport), excluding LLM inference latency, which would widen the gap further for the original.
- Phase 1 timing is dominated by factory-instrument loading and varies run-to-run.

---

# Appendix C: Design decisions and rationale

Full design notes and rollback steps are in `AbletonMCP_optimization_casestudy.md` (attached). Key points are summarised in the PR body above.
