### PR TITLE
Add set_arrangement_clip_name tool for renaming Arrangement clips

### DIFF
--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -229,6 +229,7 @@ class AbletonMCP(ControlSurface):
             # Commands that modify Live's state should be scheduled on the main thread
             elif command_type in ["create_midi_track", "set_track_name",
                                  "create_clip", "create_audio_clip", "add_notes_to_clip", "set_clip_name",
+                                 "set_arrangement_clip_name",
                                  "set_tempo", "fire_clip", "stop_clip",
                                  "start_playback", "stop_playback", "load_browser_item",
                                  # Arrangement view – must run on the main thread
@@ -268,6 +269,11 @@ class AbletonMCP(ControlSurface):
                             clip_index = params.get("clip_index", 0)
                             name = params.get("name", "")
                             result = self._set_clip_name(track_index, clip_index, name)
+                        elif command_type == "set_arrangement_clip_name":
+                            track_index = params.get("track_index", 0)
+                            clip_index = params.get("clip_index", 0)
+                            name = params.get("name", "")
+                            result = self._set_arrangement_clip_name(track_index, clip_index, name)
                         elif command_type == "set_tempo":
                             tempo = params.get("tempo", 120.0)
                             result = self._set_tempo(tempo)
@@ -647,7 +653,34 @@ class AbletonMCP(ControlSurface):
         except Exception as e:
             self.log_message("Error setting clip name: " + str(e))
             raise
-    
+
+    def _set_arrangement_clip_name(self, track_index, clip_index, name):
+        """Set the name of a clip placed in the Arrangement timeline.
+
+        clip_index indexes into track.arrangement_clips, in the same order
+        as returned by _get_arrangement_clips (i.e. ordered by start_time).
+        """
+        try:
+            if track_index < 0 or track_index >= len(self._song.tracks):
+                raise IndexError("Track index out of range")
+
+            track = self._song.tracks[track_index]
+            arrangement_clips = list(track.arrangement_clips)
+
+            if clip_index < 0 or clip_index >= len(arrangement_clips):
+                raise IndexError("Clip index out of range")
+
+            clip = arrangement_clips[clip_index]
+            clip.name = name
+
+            result = {
+                "name": clip.name
+            }
+            return result
+        except Exception as e:
+            self.log_message("Error setting arrangement clip name: " + str(e))
+            raise
+
     def _set_tempo(self, tempo):
         """Set the tempo of the session"""
         try:

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -448,6 +448,31 @@ def set_clip_name(ctx: Context, track_index: int, clip_index: int, name: str, us
         return f"Error setting clip name: {str(e)}"
 
 @mcp.tool()
+@rich_telemetry_tool("set_arrangement_clip_name")
+def set_arrangement_clip_name(ctx: Context, track_index: int, clip_index: int, name: str, user_prompt: str = "") -> str:
+    """
+    Set the name of a clip placed in the Arrangement timeline.
+
+    Parameters:
+    - track_index: The index of the track containing the clip
+    - clip_index: The index of the clip within track.arrangement_clips, in the
+      same order returned by get_arrangement_clips (i.e. ordered by start_time)
+    - name: The new name for the clip
+    - user_prompt: The original user prompt that led to this tool call (for telemetry)
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("set_arrangement_clip_name", {
+            "track_index": track_index,
+            "clip_index": clip_index,
+            "name": name
+        })
+        return f"Renamed arrangement clip at track {track_index}, index {clip_index} to '{name}'"
+    except Exception as e:
+        logger.error(f"Error setting arrangement clip name: {str(e)}")
+        return f"Error setting arrangement clip name: {str(e)}"
+
+@mcp.tool()
 @rich_telemetry_tool("set_tempo")
 def set_tempo(ctx: Context, tempo: float, user_prompt: str = "") -> str:
     """


### PR DESCRIPTION
## Summary
- `get_arrangement_clips` already exposes clips placed on the Arrangement timeline, and `set_clip_name` renames Session clip slots — but there was no write-side equivalent for Arrangement clips.
- Adds `set_arrangement_clip_name`, following the same pattern as `set_clip_name`. It indexes into `track.arrangement_clips` (same order as `get_arrangement_clips`, i.e. by `start_time`) and sets `.name` directly.
- Changes touch both halves of the integration: the MCP tool (`MCP_Server/server.py`) and the matching command handler in the Remote Script (`AbletonMCP_Remote_Script/__init__.py`).

## Use case
Labeling long stem/segment exports dropped into the Arrangement view with human-readable bar ranges — e.g. turning 20 generic 8-bar segments per track into `Drums 1-8`, `Drums 9-16`, ... across multiple tracks (drums, bass, vocals, guitar, piano, other, full mix), driven entirely through the MCP tool instead of manually renaming ~140 clips by hand in Live.

## Test plan
- [x] Verified against a live Ableton Live 11 session
- [x] Ran the new tool against ~140 real Arrangement clips across 7 audio tracks, confirmed names updated correctly in Live's UI
- [x] Confirmed `get_arrangement_clips` output still matches after renaming (clip ordering/indices unaffected)