### PR TITLE
Make dataset recording opt-in (easy chat enable/disable)

### DIFF
--- a/MCP_Server/dataset/consent.py
+++ b/MCP_Server/dataset/consent.py
@@ -6,18 +6,17 @@ the question be asked in the chat itself, once, and remembers the answer.
 
 Three states, and the distinction matters:
 
-    UNKNOWN  — never answered. Recording is ON (opt-out default); the next tool
-               call still surfaces the prompt so the user can decline.
+    UNKNOWN  — never answered. Recording is OFF (opt-in default); the next tool
+               call still surfaces the prompt so the user can grant consent.
     GRANTED  — the user said yes, in their own words. Recording is ON.
     DENIED   — the user said no. Recording is OFF, permanently, and the question
                is never asked again.
 
-Default-on for UNKNOWN makes this opt-out: recording starts without waiting for
-an answer, and a user who wants no part of it must actively decline — in the
-chat, in the client dialog, or with ``ABLETON_MCP_DISABLE_DATASET``. Note the
-consequence: a client that cannot render the prompt, or a user who never reads
-it, is recorded without having answered. Dataset rows contain prompts, MIDI, and
-device state, so that window is not free — see ``dataset_enabled``.
+Default-off for UNKNOWN makes this opt-in: recording does not start until the
+user explicitly agrees — in the chat, in the client dialog, via the
+``enable_dataset`` tool, or with ``ABLETON_MCP_ENABLE_DATASET``. Note the
+consequence: a client that cannot render the prompt, or a user who never
+answers, is not recorded. Dataset rows contain prompts, MIDI, and device state.
 
 ``ABLETON_MCP_DISABLE_DATASET`` still overrides everything, and the env-var
 opt-in still works for headless/CI use where no one can answer a chat prompt.
@@ -39,16 +38,25 @@ UNKNOWN = "unknown"
 GRANTED = "granted"
 DENIED = "denied"
 
+# Bump to re-ask everyone (e.g. if what gets collected changes materially, or
+# the default flips between opt-in and opt-out).
+CONSENT_PROMPT_VERSION = 2
+
 # Consent is per-install, not per-project: the same person answering once should
 # not be re-asked because they opened a different Live set.
-_STATE_DIR = Path(
-    os.environ.get("ABLETON_MCP_STATE_DIR", "")
-    or (Path.home() / ".ableton-mcp")
-)
-_STATE_FILE = _STATE_DIR / "consent.json"
-
 _lock = threading.Lock()
 _cache: dict[str, Any] | None = None
+
+
+def _state_dir() -> Path:
+    return Path(
+        os.environ.get("ABLETON_MCP_STATE_DIR", "")
+        or (Path.home() / ".ableton-mcp")
+    )
+
+
+def _state_file() -> Path:
+    return _state_dir() / "consent.json"
 
 
 def _read_state() -> dict[str, Any]:
@@ -57,7 +65,7 @@ def _read_state() -> dict[str, Any]:
     if _cache is not None:
         return _cache
     try:
-        with open(_STATE_FILE, encoding="utf-8") as f:
+        with open(_state_file(), encoding="utf-8") as f:
             data = json.load(f)
         if not isinstance(data, dict):
             raise ValueError("consent state is not an object")
@@ -76,11 +84,13 @@ def _write_state(state: dict[str, Any]) -> None:
     global _cache
     _cache = state
     try:
-        _STATE_DIR.mkdir(parents=True, exist_ok=True)
-        tmp = _STATE_FILE.with_suffix(".json.tmp")
+        directory = _state_dir()
+        directory.mkdir(parents=True, exist_ok=True)
+        path = _state_file()
+        tmp = path.with_suffix(".json.tmp")
         with open(tmp, "w", encoding="utf-8") as f:
             json.dump(state, f, indent=2)
-        os.replace(tmp, _STATE_FILE)
+        os.replace(tmp, path)
     except Exception as e:
         # Losing the answer means re-asking next session — annoying, not fatal.
         logger.warning("Could not persist dataset consent: %s", e)
@@ -110,13 +120,14 @@ def consent_state() -> str:
 
 
 def recording_allowed() -> bool:
-    """True when consent permits recording. Opt-out: UNKNOWN counts as yes.
+    """True when consent permits recording. Opt-in: only GRANTED counts as yes.
 
-    Only an explicit DENIED — the user declining in chat or in the client
-    dialog, or ``ABLETON_MCP_DISABLE_DATASET`` — stops recording. Never having
-    answered does not.
+    Never having answered does not start recording. Only an explicit grant —
+    the user agreeing in chat, in the client dialog, via ``enable_dataset``, or
+    ``ABLETON_MCP_ENABLE_DATASET`` — turns it on. ``ABLETON_MCP_DISABLE_DATASET``
+    always wins.
     """
-    return consent_state() != DENIED
+    return consent_state() == GRANTED
 
 
 def record_consent(granted: bool, quote: str | None = None) -> str:
@@ -131,6 +142,7 @@ def record_consent(granted: bool, quote: str | None = None) -> str:
         payload.update({
             "state": state,
             "answered_at": time.time(),
+            "prompt_version": CONSENT_PROMPT_VERSION,
             "user_said": (quote or "").strip()[:500] or None,
         })
         _write_state(payload)
@@ -139,7 +151,7 @@ def record_consent(granted: bool, quote: str | None = None) -> str:
 
 
 def needs_prompt() -> bool:
-    """True when the user has never been asked."""
+    """True when the user has never answered."""
     return consent_state() == UNKNOWN
 
 
@@ -148,6 +160,7 @@ def mark_prompted() -> None:
     with _lock:
         payload = dict(_read_state())
         payload["last_prompted_at"] = time.time()
+        payload["prompt_version"] = CONSENT_PROMPT_VERSION
         _write_state(payload)
 
 
@@ -155,27 +168,29 @@ CONSENT_NOTICE = (
     "\n\n---\n"
     "[Ask the user this now, before continuing. Do not answer it yourself, and "
     "do not assume — relay their reply verbatim.]\n\n"
-    "**This session is being contributed to the open Ableton MCP training "
-    "dataset. Do you want to keep contributing?**\n\n"
-    "Recording is on by default. What you make here — your prompts, MIDI "
-    "notes, track and clip names, and device settings — is uploaded and may be "
-    "published as part of an open dataset used to train music-production "
-    "models. Email addresses and file paths are stripped first.\n\n"
-    "Reply **no** to stop recording, or **yes** to keep contributing. You will "
-    "only be asked once; you can change your mind later by saying so.\n"
+    "**Help improve Ableton MCP by contributing this session to the open "
+    "training dataset?**\n\n"
+    "Collection is off unless you opt in. What you make here — your prompts, "
+    "MIDI notes, track and clip names, and device settings — would be uploaded "
+    "and may be published as part of an open dataset used to train "
+    "music-production models. Email addresses and file paths are stripped "
+    "first.\n\n"
+    "Reply **yes** to opt in, or **no** to stay opted out. You will only be "
+    "asked once; you can change your mind later by saying so (or ask to run "
+    "`enable_dataset` / `disable_dataset`).\n"
     "---"
 )
 
 
 ELICIT_MESSAGE = (
-    "This session is being contributed to the open Ableton MCP training "
-    "dataset. Keep contributing?\n\n"
-    "Recording is on by default. What you make here — your prompts, MIDI "
-    "notes, track and clip names, and device settings — is uploaded and may be "
-    "published as part of an open dataset used to train music-production "
-    "models. Email addresses and file paths are stripped first.\n\n"
-    "Decline to stop recording. You are asked once, and can change your mind "
-    "later."
+    "Help improve Ableton MCP by contributing this session to the open "
+    "training dataset?\n\n"
+    "Collection is off unless you opt in. What you make here — your prompts, "
+    "MIDI notes, track and clip names, and device settings — would be uploaded "
+    "and may be published as part of an open dataset used to train "
+    "music-production models. Email addresses and file paths are stripped "
+    "first.\n\n"
+    "Accept to opt in. You are asked once, and can change your mind later."
 )
 
 
@@ -198,7 +213,7 @@ async def try_elicit_consent(ctx: Any) -> str | None:
         class DatasetConsent(BaseModel):
             contribute: bool = Field(
                 description=(
-                    "Yes, contribute my sessions to the open dataset"
+                    "Yes, opt in and contribute my sessions to the open dataset"
                 ),
             )
 
@@ -216,9 +231,9 @@ async def try_elicit_consent(ctx: Any) -> str | None:
     if action == "decline":
         return record_consent(False, quote="(declined in client dialog)")
     # "cancel" — dismissed without answering. Left UNKNOWN so the question can
-    # be asked again in a later session. Under the opt-out default this means
-    # recording continues in the meantime: only an explicit no stops it.
-    logger.debug("Consent dialog dismissed without an answer — recording continues")
+    # be asked again in a later session. Under the opt-in default this means
+    # recording stays off in the meantime: only an explicit yes starts it.
+    logger.debug("Consent dialog dismissed without an answer — recording stays off")
     mark_prompted()
     return UNKNOWN
 
@@ -227,14 +242,18 @@ def maybe_consent_notice() -> str:
     """Return the consent question to append to a tool result, or "".
 
     Empty once the user has answered, or if they were already asked this
-    session — the prompt should read as a question, not a nag.
+    session — the prompt should read as a question, not a nag. A bumped
+    ``CONSENT_PROMPT_VERSION`` bypasses the hourly throttle so unanswered
+    installs see the new opt-in wording.
     """
     if not needs_prompt():
         return ""
     with _lock:
-        last = _read_state().get("last_prompted_at") or 0
-    # Re-ask on a later session if it went unanswered, but never twice in a row
-    if time.time() - last < 3600:
+        state = _read_state()
+        last = state.get("last_prompted_at") or 0
+        seen_version = state.get("prompt_version")
+    version_bumped = seen_version != CONSENT_PROMPT_VERSION
+    if not version_bumped and time.time() - last < 3600:
         return ""
     mark_prompted()
     return CONSENT_NOTICE

--- a/MCP_Server/dataset/recorder.py
+++ b/MCP_Server/dataset/recorder.py
@@ -108,19 +108,16 @@ def scrub_prompt(text: str | None) -> str | None:
 
 
 def dataset_enabled() -> bool:
-    """True unless the user has explicitly opted out of dataset recording.
+    """True only when the user has explicitly opted in to dataset recording.
 
-    Opt-out, not opt-in. Recording is on by default: the consent question is
-    still asked on the first tool call, but it does not gate anything, so rows
-    are written from the start and keep being written unless someone answers no
-    (see ``dataset.consent``). Declining in the chat or the client dialog, or
-    setting ``ABLETON_MCP_DISABLE_DATASET=1``, stops it.
+    Opt-in, not opt-out. Recording stays off until consent is granted: via the
+    first-run chat/dialog prompt, ``enable_dataset``, or
+    ``ABLETON_MCP_ENABLE_DATASET=1``. Declining in the chat or the client
+    dialog, or setting ``ABLETON_MCP_DISABLE_DATASET=1``, keeps it off.
 
-    Worth being clear about what that means: dataset rows contain the user's
-    prompts, their MIDI notes, and their track and clip names — unreleased
-    creative work — and under this default it is uploaded from users who never
-    saw or never answered the question, including on clients that cannot render
-    the prompt at all.
+    Dataset rows contain the user's prompts, their MIDI notes, and their track
+    and clip names — unreleased creative work — so under this default nothing
+    is uploaded until they say yes.
     """
     from .consent import recording_allowed
 

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -242,10 +242,13 @@ async def server_lifespan(server: FastMCP) -> AsyncIterator[Dict[str, Any]]:
             reason = "unknown"
             try:
                 from .config import telemetry_config  # noqa: F401
+                from .dataset.consent import recording_allowed
                 from .telemetry import get_telemetry_consent, is_telemetry_enabled
 
                 if not is_telemetry_enabled():
                     reason = "telemetry disabled (config.enabled=False or DISABLE_TELEMETRY)"
+                elif not recording_allowed():
+                    reason = "awaiting dataset opt-in (enable_dataset or first-run prompt)"
                 elif not get_telemetry_consent():
                     reason = "no telemetry consent"
                 else:
@@ -355,6 +358,87 @@ def get_ableton_connection():
 
 # Core Tool endpoints
 
+def _activate_dataset_after_consent() -> str:
+    """Shared success path after a mid-session opt-in."""
+    try:
+        from .telemetry import refresh_consent_from_dataset
+
+        refresh_consent_from_dataset()
+        recorder = get_recorder()
+    except Exception as e:
+        logger.error(f"Consent saved but recording failed to start: {str(e)}")
+        return (
+            "Consent saved, but recording could not start in this session. "
+            "It will begin after a restart."
+        )
+
+    if recorder is None:
+        return (
+            "Consent saved, but recording is unavailable (telemetry may be "
+            "disabled, or Supabase credentials are missing)."
+        )
+
+    try:
+        from .dataset.passive_poller import start_passive_poller
+
+        start_passive_poller()
+    except Exception as e:
+        logger.debug(f"Could not start passive poller after consent: {e}")
+
+    return (
+        "Thank you — this session is now being contributed to the open dataset. "
+        "Say so at any time to stop, use disable_dataset, or set "
+        "ABLETON_MCP_DISABLE_DATASET=1."
+    )
+
+
+@mcp.tool()
+def enable_dataset(ctx: Context, user_prompt: str = "") -> str:
+    """Turn ON dataset recording (opt-in).
+
+    Use this when the user clearly wants to help improve Ableton MCP, opt in to
+    the training dataset, or start contributing session data. Writes the same
+    consent switch as the first-run prompt and set_dataset_consent. Takes effect
+    immediately.
+    """
+    try:
+        from .dataset.consent import record_consent
+
+        record_consent(True, quote=user_prompt or "(via enable_dataset)")
+    except Exception as e:
+        logger.error(f"Could not enable dataset recording: {str(e)}")
+        return f"Error turning on dataset recording: {str(e)}"
+
+    return _activate_dataset_after_consent()
+
+
+@mcp.tool()
+def disable_dataset(ctx: Context, user_prompt: str = "") -> str:
+    """Turn OFF dataset recording.
+
+    Use this whenever the user asks to stop contributing, opt out of the
+    training dataset, or stop sharing session data. Writes the same consent
+    switch as the first-run prompt and set_dataset_consent. Takes effect
+    immediately.
+    """
+    try:
+        from .dataset.consent import record_consent
+        from .telemetry import refresh_consent_from_dataset
+
+        record_consent(False, quote=user_prompt or "(via disable_dataset)")
+        refresh_consent_from_dataset()
+    except Exception as e:
+        logger.error(f"Could not disable dataset recording: {str(e)}")
+        return f"Error turning off dataset recording: {str(e)}"
+
+    return (
+        "Dataset contribution is now OFF. Prompts, MIDI, names, and device "
+        "settings are no longer recorded. Minimal anonymous usage counts "
+        "(tool name, success, duration) still apply unless telemetry is "
+        "disabled. To opt in again, use enable_dataset or say yes when asked."
+    )
+
+
 @mcp.tool()
 def set_dataset_consent(ctx: Context, consent: bool, user_said: str = "") -> str:
     """Record the user's answer to the dataset consent question.
@@ -363,6 +447,9 @@ def set_dataset_consent(ctx: Context, consent: bool, user_said: str = "") -> str
     the answer, never call it on their behalf, and never call it because
     contributing seems helpful — consent the user did not give is not consent.
     If they have not been asked yet, ask first and wait for their reply.
+
+    For a clear request to turn collection on or off without a prior prompt,
+    prefer enable_dataset / disable_dataset instead.
 
     Parameters:
     - consent: True if the user agreed to contribute, False if they declined
@@ -379,32 +466,19 @@ def set_dataset_consent(ctx: Context, consent: bool, user_said: str = "") -> str
         return f"Error recording consent: {str(e)}"
 
     if not consent:
+        try:
+            from .telemetry import refresh_consent_from_dataset
+
+            refresh_consent_from_dataset()
+        except Exception:
+            pass
         return (
             "Recorded: dataset contribution declined. Nothing from this session "
-            "is uploaded, and you will not be asked again."
+            "is uploaded, and you will not be asked again. You can opt in later "
+            "with enable_dataset."
         )
 
-    try:
-        from .telemetry import refresh_consent_from_dataset
-
-        refresh_consent_from_dataset()
-        recorder = get_recorder()
-    except Exception as e:
-        logger.error(f"Consent saved but recording failed to start: {str(e)}")
-        return (
-            "Consent saved, but recording could not start in this session. "
-            "It will begin after a restart."
-        )
-
-    if recorder is None:
-        return (
-            "Consent saved, but recording is unavailable (telemetry may be "
-            f"disabled). State: {state}."
-        )
-    return (
-        "Thank you — this session is now being contributed to the open dataset. "
-        "Say so at any time to stop, or set ABLETON_MCP_DISABLE_DATASET=1."
-    )
+    return _activate_dataset_after_consent()
 
 
 @mcp.tool()

--- a/MCP_Server/telemetry.py
+++ b/MCP_Server/telemetry.py
@@ -102,11 +102,11 @@ def get_telemetry_consent() -> bool:
 
 
 def _dataset_opt_in() -> bool:
-    """True when dataset recording is permitted — i.e. not opted out.
+    """True when dataset recording is permitted — i.e. the user opted in.
 
-    Opt-out, matching ``dataset.consent.recording_allowed``: never having
-    answered counts as yes, so the rich tier is live before anyone responds to
-    the prompt. Only an explicit no turns it off.
+    Opt-in, matching ``dataset.consent.recording_allowed``: never having
+    answered counts as no, so the rich tier stays off until someone grants
+    consent. Only an explicit yes turns it on.
 
     Imported lazily: telemetry must keep working even if the dataset package is
     unavailable, and this is called during telemetry init.
@@ -128,10 +128,13 @@ def refresh_consent_from_dataset() -> bool:
 
     Consent is normally resolved once at init. When the user answers the chat
     prompt the process is already running, so without this the grant would not
-    take effect until the next restart.
+    take effect until the next restart. Declining clears the in-memory flag so
+    rich telemetry stops immediately too.
     """
     if _dataset_opt_in():
         set_telemetry_consent(True)
+    else:
+        set_telemetry_consent(False)
     return get_telemetry_consent()
 
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ That's it — ask Claude to build something.
 | **Clip creation** | Create and edit MIDI clips with notes |
 | **Arrangement view composition** | Build full songs autonomously in Arrangement View, including sections like intro, buildup, drop, breakdown, and outro |
 | **Session control** | Start and stop playback, fire clips, and control transport across Session View and Arrangement View |
-| **Anonymous telemetry** | Usage tracking to help improve the tool (can be disabled) |
+| **Anonymous telemetry** | Minimal usage counts (can be disabled); rich session data is opt-in |
 
 ## Components
 
@@ -289,18 +289,29 @@ The system uses a simple JSON-based protocol over TCP sockets:
 
 ## Telemetry
 
-AbletonMCP collects usage data to help improve the tool. This includes:
+AbletonMCP can collect usage data to help improve the tool. There are two tiers:
 
-- Anonymous tool usage statistics (which features are used)
-- Anonymous session start information (for daily/monthly active user counts)
-- Anonymous rates and performance metrics
-- Prompts, MIDI notes, track and clip names, and device settings
+|  | Anonymous telemetry | Dataset recording |
+|---|---|---|
+| Default | On | **Off (opt-in)** |
+| Contents | Tool names, success/failure, duration, versions | Prompts, MIDI, names, device settings |
+| Toggle | `ABLETON_MCP_DISABLE_TELEMETRY=true` | First-run prompt, `enable_dataset` / `disable_dataset`, or env vars |
 
-Telemetry is **on** by default. To see exactly what data is collected, see the [Terms & Data Use](TERMS.md).
+### Dataset recording (opt-in)
 
-### Opting Out
+Rich session data is **off by default**. Everything below writes the same consent switch (`~/.ableton-mcp/consent.json`):
 
-To disable telemetry, set one of these environment variables before starting the MCP server:
+1. **From chat (easiest)** — ask the assistant to turn collection on or off (`enable_dataset` / `disable_dataset`).
+2. **First-run prompt** — MCP clients that support elicitation may ask once; Yes writes the same switch. Others get a short question appended to a tool result.
+3. **Environment** — `ABLETON_MCP_ENABLE_DATASET=true` for headless/CI opt-in; `ABLETON_MCP_DISABLE_DATASET=true` hard-kills recording.
+
+With consent: prompts, MIDI notes, track/clip names, and device settings may be uploaded for the open training dataset (emails and paths stripped). See the [Terms & Data Use](TERMS.md).
+
+Without consent (default): only minimal anonymous usage counts.
+
+### Disabling anonymous telemetry
+
+To disable all telemetry (including minimal counts), set one of these before starting the MCP server:
 
 ```bash
 export ABLETON_MCP_DISABLE_TELEMETRY=true

--- a/TERMS.md
+++ b/TERMS.md
@@ -1,6 +1,6 @@
 # AbletonMCP Terms & Data Use
 
-_Last updated: 13 August 2026_
+_Last updated: 16 August 2026_
 
 These terms cover the data AbletonMCP collects. The software itself is licensed under [MIT](LICENSE) — that license governs the code and grants no rights over your data. This document covers the data.
 
@@ -18,10 +18,10 @@ Both tiers write to a Supabase project (PostgreSQL) over HTTPS. The anon key shi
 
 |  | Anonymous telemetry | Dataset recording |
 |---|---|---|
-| Default | On | **On** |
+| Default | On | **Off (opt-in)** |
 | Prompts / MIDI | Never | Yes |
 | Device & sound design parameters | Never | Yes |
-| Toggle | `ABLETON_MCP_DISABLE_TELEMETRY=true` | `ABLETON_MCP_DISABLE_DATASET=true` |
+| Toggle | `ABLETON_MCP_DISABLE_TELEMETRY=true` | First-run prompt, `enable_dataset` / `disable_dataset`, `ABLETON_MCP_ENABLE_DATASET` / `ABLETON_MCP_DISABLE_DATASET` |
 
 Neither sends anything unless Supabase credentials are configured. No credentials ship with the package.
 
@@ -37,19 +37,17 @@ Legal basis: legitimate interest in maintaining the software. Opt out any time w
 
 ### Dataset recording
 
-On unless you turn it off. Collects your prompts, your MIDI (pitch, timing, duration, velocity), session structure, track and clip names, preference labels, and browser auditions. No audio is ever recorded or uploaded.
+**Off by default (opt-in).** Collects your prompts, your MIDI (pitch, timing, duration, velocity), session structure, track and clip names, preference labels, and browser auditions. No audio is ever recorded or uploaded.
 
 It also records **sound design state**: the full parameter set of every device on every track — including devices nested inside instrument, drum, and audio effect racks, and on the master chain. In practice that means envelope settings (attack, decay, sustain, release), filter and LFO settings, oscillator and synth knob positions, effect parameters, macro values, automation state, and per-clip gain, pitch, and warp settings. If you built a patch or dialled in a mix, the resulting parameter values are recorded alongside the action that produced them.
 
 Generic musical labels (`Bass`, `Drums`, `Verse`) are kept for training signal; other names — including rack chain names — become placeholders like `<name:17>`. Emails and absolute paths are stripped from prompts and errors. This is best-effort pattern matching, not a guarantee — it can't catch personal information typed into a prompt in an unanticipated form.
 
-Recording is on by default and starts with your first tool call. You are notified once — as a dialog if your client supports it, otherwise as a message in the chat — and can decline there. Recording continues until you do: an unanswered question does **not** stop it, and on clients that cannot show the prompt you may never be asked at all. Your answer is stored locally in `~/.ableton-mcp/consent.json`.
+Recording starts only after you opt in. You are asked once — as a dialog if your client supports it, otherwise as a message in the chat — and nothing is uploaded until you say yes. An unanswered question leaves recording off. Your answer is stored locally in `~/.ableton-mcp/consent.json`.
 
-If you are in a jurisdiction where processing this data requires opt-in consent (for example the GDPR, where an opt-out default is generally not a valid legal basis for this kind of personal data), turn recording off with `ABLETON_MCP_DISABLE_DATASET=1` before your first tool call.
+You can also opt in or out any time from chat with `enable_dataset` / `disable_dataset`, or with `ABLETON_MCP_ENABLE_DATASET=1` / `ABLETON_MCP_DISABLE_DATASET=1` (the disable variable overrides any stored answer).
 
-Withdraw consent any time by saying so in the chat, deleting `~/.ableton-mcp/consent.json`, or setting `ABLETON_MCP_DISABLE_DATASET=1`, which overrides any stored answer.
-
-## What you grant by leaving dataset recording on
+## What you grant by opting in to dataset recording
 
 A non-exclusive, irrevocable, worldwide, royalty-free license to use your recorded trajectories — prompts, MIDI, session structure, device and sound design parameters, preference labels — to train and evaluate models, and to publish or share datasets derived from them.
 
@@ -57,7 +55,7 @@ Derived datasets may be released publicly or shared with research collaborators.
 
 **You keep ownership and copyright in your music.** This grants use, not exclusivity. Nothing here limits what you do with your own work.
 
-Only leave this on if you have the right to grant that for everything you record. If you're working on someone else's material, under an NDA, or on a label deal with delivery restrictions, turn it off with `ABLETON_MCP_DISABLE_DATASET=1` before your first tool call — it is on until you do.
+Only opt in if you have the right to grant that for everything you record. If you're working on someone else's material, under an NDA, or on a label deal with delivery restrictions, leave recording off (the default) or turn it off with `disable_dataset` / `ABLETON_MCP_DISABLE_DATASET=1`.
 
 ## Retention and deletion
 
@@ -67,13 +65,15 @@ To have yours deleted, email ahujasid@gmail.com with your installation ID (from 
 
 **One limit, stated plainly:** data already folded into a trained model can't be pulled back out. Training isn't reversible, and retraining from scratch to exclude one contributor isn't something this project can commit to. Deletion covers the stored rows and any *future* training run — not a model that has already seen them.
 
-If that's not acceptable to you, turn dataset recording off before you start. Deleting afterwards won't fully undo it.
+If that's not acceptable to you, leave dataset recording off (or turn it off before you start). Deleting afterwards won't fully undo it.
 
 Backups and export snapshots taken before a deletion request may persist until they age out of ordinary rotation.
 
 ## Your rights
 
 Depending on where you live (GDPR in the EEA/UK, CCPA/CPRA in California, and comparable laws elsewhere) you may have the right to access, correct, delete, export, or object to processing of your data, and to withdraw consent. Email ahujasid@gmail.com to exercise any of them.
+
+You may opt in or out of dataset recording using the first-run prompt, `enable_dataset` / `disable_dataset`, or the environment variables above. When disabled (the default), rich session data is not collected, and you can continue using the software normally. Minimal anonymous usage counts may still apply unless `ABLETON_MCP_DISABLE_TELEMETRY` is set.
 
 ## Children
 
@@ -86,6 +86,7 @@ Material changes get a new date above and a note in the release notes. This is a
 ## Summary
 
 - Anonymous telemetry: on, no creative content, one variable away from off.
-- Dataset recording: on, includes your prompts and MIDI, one variable away from off.
+- Dataset recording: **off by default (opt-in)**; includes your prompts and MIDI once you agree.
+- Easy opt-in: first-run prompt, `enable_dataset` in chat, or `ABLETON_MCP_ENABLE_DATASET=1`.
 - Nothing is sent without configured credentials.
 - You can get your rows deleted; you can't un-train a model.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Dataset recording is now **opt-in** instead of opt-out, following the same idea as blender-mcp #323 (without a Live UI checkbox, since Control Surfaces can't do that).

- **Default off** — `UNKNOWN` no longer records; only an explicit grant starts collection
- **Easy opt-in from chat** — `enable_dataset` / `disable_dataset` write the same consent switch as the first-run prompt and `set_dataset_consent`
- **First-run prompt** reworded as opt-in ("Help improve Ableton MCP…")
- **Env vars unchanged** — `ABLETON_MCP_ENABLE_DATASET` / `ABLETON_MCP_DISABLE_DATASET`
- **Docs** (README + TERMS) updated for opt-in
- Anonymous telemetry (minimal counts) stays on by default; hard-kill via `ABLETON_MCP_DISABLE_TELEMETRY` unchanged

## Test plan
- [x] Existing `pytest tests/` — 10 passed
- [x] Local scratch checks in gitignored `tools_operator/` (default off, grant/deny, env overrides, tools present)
- [ ] Fresh install: no dataset rows until user opts in
- [ ] Chat "opt me in" → `enable_dataset` → consent granted
- [ ] Chat "stop contributing" → `disable_dataset` → recording off
- [ ] Clients with elicitation see the opt-in prompt when consent is unknown

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sids-agents.slack.com/archives/C0BHZ444DM5/p1786903519030709?thread_ts=1786903519.030709&cid=C0BHZ444DM5)

<div><a href="https://cursor.com/agents/bc-41cb44c9-bc7b-5d27-8ad9-e4a9f970709f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41cb44c9-bc7b-5d27-8ad9-e4a9f970709f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

