### PR TITLE
Add mixer control: volume, panning and sends

### DIFF
--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -278,6 +278,9 @@ class AbletonMCP(ControlSurface):
             elif command_type == "get_track_info":
                 track_index = params.get("track_index", 0)
                 response["result"] = self._get_track_info(track_index)
+            elif command_type == "get_mixer":
+                response["result"] = self._get_mixer(
+                    params.get("track_index", 0), params.get("track_type", "track"))
             # Commands that modify Live's state should be scheduled on the main thread
             elif command_type in ["create_midi_track", "create_audio_track", "set_track_name",
                                  "create_clip", "create_audio_clip", "add_notes_to_clip", "set_clip_name",
@@ -291,7 +294,9 @@ class AbletonMCP(ControlSurface):
                                  "switch_to_arrangement_view", "set_current_song_time",
                                  "duplicate_session_clip_to_arrangement",
                                  "map_rack_magnitude", "inspect_rack",
-                                 "create_locator"]:
+                                 "create_locator",
+                                 # Mixer – must run on the main thread
+                                 "set_track_volume", "set_track_panning", "set_send"]:
                 # Use a thread-safe approach with a response queue
                 response_queue = queue.Queue()
                 
@@ -391,6 +396,25 @@ class AbletonMCP(ControlSurface):
                             name = params.get("name", "")
                             time_val = params.get("time", 0.0)
                             result = self._create_locator(name, time_val)
+                        # ── Mixer commands ─────────────────────────────────────────
+                        elif command_type == "set_track_volume":
+                            result = self._set_track_volume(
+                                params.get("track_index", 0),
+                                params.get("db", None),
+                                params.get("value", None),
+                                params.get("track_type", "track"))
+                        elif command_type == "set_track_panning":
+                            result = self._set_track_panning(
+                                params.get("track_index", 0),
+                                params.get("value", 0.0),
+                                params.get("track_type", "track"))
+                        elif command_type == "set_send":
+                            result = self._set_send(
+                                params.get("track_index", 0),
+                                params.get("send_index", 0),
+                                params.get("db", None),
+                                params.get("value", None),
+                                params.get("track_type", "track"))
 
                         # Put the result in the queue
                         response_queue.put({"status": "success", "result": result})
@@ -646,6 +670,164 @@ class AbletonMCP(ControlSurface):
             self.log_message("Error creating audio track: " + str(e))
             raise
 
+    # ------------------------------------------------------------------
+    # Mixer
+    # ------------------------------------------------------------------
+
+    def _resolve_track(self, track_index, track_type="track"):
+        """Resolve a mixer target to a Live track object.
+
+        track_type is one of "track", "return" or "master". For "master" the
+        index is ignored.
+        """
+        track_type = (track_type or "track").lower()
+        if track_type == "master":
+            return self._song.master_track
+        if track_type == "return":
+            tracks = self._song.return_tracks
+        elif track_type == "track":
+            tracks = self._song.tracks
+        else:
+            raise Exception("Unknown track_type '%s' (expected track, return or master)" % track_type)
+        if track_index < 0 or track_index >= len(tracks):
+            raise IndexError("%s index %s out of range (have %d)" % (track_type, track_index, len(tracks)))
+        return tracks[track_index]
+
+    def _db_for_value(self, param, value):
+        """Return the dB a normalized parameter value displays as in Live.
+
+        Live's fader taper has no published closed form, so rather than
+        approximating it we ask Live what the value actually reads as and
+        parse that. This stays correct across Live versions.
+        """
+        text = param.str_for_value(value)
+        if not isinstance(text, str):
+            try:
+                text = text.encode("utf-8")
+            except Exception:
+                text = str(text)
+        # Normalize the unicode minus Live uses and locale decimal commas.
+        text = text.replace("\xe2\x88\x92", "-").replace("−", "-")
+        text = text.replace("dB", "").replace(",", ".").strip()
+        if "inf" in text.lower():
+            return float("-inf")
+        cleaned = "".join([c for c in text if c.isdigit() or c in "-+."])
+        try:
+            return float(cleaned)
+        except Exception:
+            raise Exception("Could not parse dB from Live display '%s'" % param.str_for_value(value))
+
+    def _value_for_db(self, param, target_db):
+        """Find the normalized value whose display matches target_db.
+
+        dB rises monotonically with the fader value, so bisect against Live's
+        own readout. ~40 steps exhausts float precision over the 0..1 range.
+
+        Accuracy is bounded by Live's display resolution of 0.01 dB, which is
+        two orders of magnitude below audibility. Targets outside the fader
+        range clamp to its ends rather than raising.
+        """
+        target_db = float(target_db)
+        low, high = param.min, param.max
+        if target_db <= self._db_for_value(param, low):
+            return low
+        if target_db >= self._db_for_value(param, high):
+            return high
+        for _ in range(40):
+            mid = (low + high) / 2.0
+            if self._db_for_value(param, mid) < target_db:
+                low = mid
+            else:
+                high = mid
+        return (low + high) / 2.0
+
+    def _param_report(self, param):
+        """Describe a mixer parameter as raw value, dB and Live's own display."""
+        report = {
+            "value": param.value,
+            "display": param.str_for_value(param.value),
+        }
+        try:
+            report["db"] = self._db_for_value(param, param.value)
+        except Exception:
+            # panning and other non-dB parameters simply have no dB reading
+            report["db"] = None
+        return report
+
+    def _apply_param(self, param, db=None, value=None):
+        """Set a mixer parameter from either a dB target or a raw 0..1 value."""
+        if value is not None:
+            param.value = max(param.min, min(param.max, float(value)))
+        elif db is not None:
+            param.value = self._value_for_db(param, db)
+        else:
+            raise Exception("Provide either 'db' or 'value'")
+        return self._param_report(param)
+
+    def _get_mixer(self, track_index, track_type="track"):
+        """Read volume, panning and sends for a mixer target."""
+        try:
+            track = self._resolve_track(track_index, track_type)
+            mixer = track.mixer_device
+            sends = []
+            # The master track has no sends.
+            for i, send in enumerate(getattr(mixer, "sends", []) or []):
+                entry = self._param_report(send)
+                entry["index"] = i
+                entry["name"] = send.name
+                sends.append(entry)
+            return {
+                "name": track.name,
+                "track_type": (track_type or "track").lower(),
+                "volume": self._param_report(mixer.volume),
+                "panning": self._param_report(mixer.panning),
+                "sends": sends,
+            }
+        except Exception as e:
+            self.log_message("Error getting mixer: " + str(e))
+            raise
+
+    def _set_track_volume(self, track_index, db=None, value=None, track_type="track"):
+        """Set a track's volume, either to a dB target or a raw 0..1 value."""
+        try:
+            track = self._resolve_track(track_index, track_type)
+            result = self._apply_param(track.mixer_device.volume, db, value)
+            result["name"] = track.name
+            return result
+        except Exception as e:
+            self.log_message("Error setting track volume: " + str(e))
+            raise
+
+    def _set_track_panning(self, track_index, value, track_type="track"):
+        """Set a track's pan position. -1.0 is hard left, 1.0 is hard right."""
+        try:
+            track = self._resolve_track(track_index, track_type)
+            param = track.mixer_device.panning
+            param.value = max(param.min, min(param.max, float(value)))
+            result = self._param_report(param)
+            result["name"] = track.name
+            return result
+        except Exception as e:
+            self.log_message("Error setting track panning: " + str(e))
+            raise
+
+    def _set_send(self, track_index, send_index, db=None, value=None, track_type="track"):
+        """Set one of a track's send levels."""
+        try:
+            track = self._resolve_track(track_index, track_type)
+            sends = getattr(track.mixer_device, "sends", []) or []
+            if send_index < 0 or send_index >= len(sends):
+                raise IndexError("Send index %s out of range (track '%s' has %d sends)"
+                                 % (send_index, track.name, len(sends)))
+            send = sends[send_index]
+            result = self._apply_param(send, db, value)
+            result["name"] = track.name
+            result["send"] = send.name
+            result["index"] = send_index
+            return result
+        except Exception as e:
+            self.log_message("Error setting send: " + str(e))
+            raise
 
     def _set_track_name(self, track_index, name):
         """Set the name of a track"""

--- a/MCP_Server/dataset/trajectory_decorator.py
+++ b/MCP_Server/dataset/trajectory_decorator.py
@@ -38,6 +38,9 @@ MODIFYING_TOOLS = {
     "load_instrument_or_effect",
     "load_drum_kit",
     "duplicate_to_arrangement",
+    "set_track_volume",
+    "set_track_panning",
+    "set_send",
 }
 
 _PARAM_KEYS = (

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -7,7 +7,7 @@ import os
 import threading
 from dataclasses import dataclass, field
 from contextlib import asynccontextmanager
-from typing import AsyncIterator, Dict, Any, List, Union
+from typing import AsyncIterator, Dict, Any, List, Optional, Union
 
 from .telemetry import record_startup
 from .telemetry_decorator import telemetry_tool, rich_telemetry_tool
@@ -1549,6 +1549,146 @@ def record_audition(
         return f"Error recording audition: {str(e)}"
 
 
+# ── Mixer tools ───────────────────────────────────────────────────────────────
+
+@mcp.tool()
+@telemetry_tool("get_mixer")
+@trajectory_tool("get_mixer")
+def get_mixer(ctx: Context, track_index: int = 0, track_type: str = "track",
+              user_prompt: str = "") -> str:
+    """
+    Get the mixer state (volume, panning and sends) for a track.
+
+    Each value is reported three ways: the raw 0..1 parameter value, the dB it
+    corresponds to, and the string Live itself displays.
+
+    Parameters:
+    - track_index: The index of the track (ignored when track_type is "master")
+    - track_type: "track" (default), "return", or "master"
+    - user_prompt: The original user prompt that led to this tool call (for telemetry)
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("get_mixer", {
+            "track_index": track_index,
+            "track_type": track_type
+        })
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        logger.error(f"Error getting mixer: {str(e)}")
+        return f"Error getting mixer: {str(e)}"
+
+@mcp.tool()
+@rich_telemetry_tool("set_track_volume")
+@trajectory_tool("set_track_volume")
+def set_track_volume(
+    ctx: Context,
+    track_index: int,
+    db: Optional[float] = None,
+    value: Optional[float] = None,
+    track_type: str = "track",
+    user_prompt: str = ""
+) -> str:
+    """
+    Set a track's volume fader.
+
+    Prefer `db` — Live's fader taper is non-linear, so the raw 0..1 value is not
+    proportional to level (0.85 is 0 dB, 1.0 is +6 dB). Passing `db` resolves the
+    exact fader position for that level using Live's own readout.
+
+    Parameters:
+    - track_index: The index of the track (ignored when track_type is "master")
+    - db: Target level in decibels, e.g. -4.0. Clamped to the fader range.
+    - value: Raw fader position 0.0-1.0, as an alternative to db
+    - track_type: "track" (default), "return", or "master"
+    - user_prompt: The original user prompt that led to this tool call (for telemetry)
+    """
+    try:
+        if db is None and value is None:
+            return "Error: provide either db or value"
+        ableton = get_ableton_connection()
+        result = ableton.send_command("set_track_volume", {
+            "track_index": track_index,
+            "db": db,
+            "value": value,
+            "track_type": track_type
+        })
+        return f"Set volume of '{result.get('name')}' to {result.get('display')}"
+    except Exception as e:
+        logger.error(f"Error setting track volume: {str(e)}")
+        return f"Error setting track volume: {str(e)}"
+
+@mcp.tool()
+@rich_telemetry_tool("set_track_panning")
+@trajectory_tool("set_track_panning")
+def set_track_panning(
+    ctx: Context,
+    track_index: int,
+    value: float,
+    track_type: str = "track",
+    user_prompt: str = ""
+) -> str:
+    """
+    Set a track's pan position.
+
+    Parameters:
+    - track_index: The index of the track (ignored when track_type is "master")
+    - value: -1.0 is hard left, 0.0 is centre, 1.0 is hard right
+    - track_type: "track" (default), "return", or "master"
+    - user_prompt: The original user prompt that led to this tool call (for telemetry)
+    """
+    try:
+        ableton = get_ableton_connection()
+        result = ableton.send_command("set_track_panning", {
+            "track_index": track_index,
+            "value": value,
+            "track_type": track_type
+        })
+        return f"Set panning of '{result.get('name')}' to {result.get('display')}"
+    except Exception as e:
+        logger.error(f"Error setting track panning: {str(e)}")
+        return f"Error setting track panning: {str(e)}"
+
+@mcp.tool()
+@rich_telemetry_tool("set_send")
+@trajectory_tool("set_send")
+def set_send(
+    ctx: Context,
+    track_index: int,
+    send_index: int,
+    db: Optional[float] = None,
+    value: Optional[float] = None,
+    track_type: str = "track",
+    user_prompt: str = ""
+) -> str:
+    """
+    Set one of a track's send levels.
+
+    As with volume, prefer `db` over the raw value. The master track has no sends.
+
+    Parameters:
+    - track_index: The index of the track
+    - send_index: Which send to set (0 is the first return track, A)
+    - db: Target send level in decibels, e.g. -12.0
+    - value: Raw send position 0.0-1.0, as an alternative to db
+    - track_type: "track" (default) or "return"
+    - user_prompt: The original user prompt that led to this tool call (for telemetry)
+    """
+    try:
+        if db is None and value is None:
+            return "Error: provide either db or value"
+        ableton = get_ableton_connection()
+        result = ableton.send_command("set_send", {
+            "track_index": track_index,
+            "send_index": send_index,
+            "db": db,
+            "value": value,
+            "track_type": track_type
+        })
+        return f"Set send {result.get('send')} on '{result.get('name')}' to {result.get('display')}"
+    except Exception as e:
+        logger.error(f"Error setting send: {str(e)}")
+        return f"Error setting send: {str(e)}"
 
 # Main execution
 def main():

--- a/README.md
+++ b/README.md
@@ -241,6 +241,40 @@ Once the config file has been set on Claude, and the remote script is running in
 - Load instruments and effects from Ableton's browser
 - Add notes to MIDI clips
 - Change tempo and other session parameters
+- Read and set mixer levels — volume, panning and sends
+
+### Mixer control
+
+`get_mixer`, `set_track_volume`, `set_track_panning` and `set_send` work on
+regular tracks, return tracks and the master (`track_type` is `"track"`,
+`"return"` or `"master"`).
+
+Levels are set in decibels:
+
+```
+set_track_volume(track_index=0, db=-4)
+set_send(track_index=0, send_index=0, db=-12)
+```
+
+Prefer `db` over the raw `value`. Live's fader position is not proportional to
+level — 0.85 is 0 dB and 1.0 is +6 dB — and the taper has no published closed
+form, so approximating it drifts away from unity gain. Passing `db` resolves the
+exact fader position by bisecting against `DeviceParameter.str_for_value()`,
+i.e. asking Live what a position actually reads as. Accuracy is bounded by
+Live's own 0.01 dB display resolution. Targets beyond the fader range clamp to
+its ends.
+
+`get_mixer` reports each parameter three ways — the raw value, the dB, and the
+string Live displays:
+
+```json
+{
+  "name": "1-Drums",
+  "volume": { "value": 0.85, "db": 0.0, "display": "0.0 dB" },
+  "panning": { "value": 0.0, "db": null, "display": "C" },
+  "sends": [ { "index": 0, "name": "A Reverb", "db": -12.0, "display": "-12.0 dB" } ]
+}
+```
 
 ### Example Commands
 
@@ -259,6 +293,8 @@ Here are some examples of what you can ask Claude to do:
 | *"Add a jazz chord progression to the clip in track 1"* | |
 | *"Set the tempo to 120 BPM"* | |
 | *"Play the clip in track 2"* | |
+| *"Set every track to -4 dB"* | |
+| *"Pan the hats 30% left and send them to the reverb at -12 dB"* | |
 
 ---
 


### PR DESCRIPTION
## The gap

Mixer levels are readable but not writable. `get_track_info` returns
`mixer_device.volume.value`, but there is no way to set it — `set_device_parameter`
resolves through `track.devices[...]`, so the mixer itself is out of reach. Same for
panning and sends.

In practice this means you can ask Claude to build an arrangement but not to balance
it, which is where a lot of the useful work is.

## What this adds

Four commands, covering regular tracks, return tracks and the master
(`track_type` is `"track"`, `"return"` or `"master"`):

| command | purpose |
|---|---|
| `get_mixer` | read volume, panning and all sends |
| `set_track_volume` | set the volume fader |
| `set_track_panning` | set pan position |
| `set_send` | set one send level |

## Levels are addressed in dB

This is the part worth reviewing closely.

Live's fader position is not proportional to level — `0.85` is 0 dB, `1.0` is +6 dB —
and the taper has no published closed form. The usual workaround is to approximate it
(commonly "0.85 is 0 dB, linear at 40 dB per unit from there"), which is fine near
unity and drifts badly away from it.

Rather than approximating, this asks Live directly. `DeviceParameter.str_for_value(v)`
returns what a given position displays as (`"-4.00 dB"`). Since dB rises monotonically
with fader position, bisecting against that readout lands on any dB target exactly —
and stays correct if the taper ever changes between versions.

```python
set_track_volume(track_index=0, db=-4)
set_send(track_index=0, send_index=0, db=-12)
```

The raw `value` path is still available for callers that want it.

Accuracy is bounded by Live's own display resolution of 0.01 dB, two orders of
magnitude below audibility. Targets beyond the fader range clamp to its ends rather
than raising.

## Notes for review

- `get_mixer` is a read and deliberately stays **off** the main-thread queue; the three
  setters mutate and are scheduled on it.
- The remote script stays **Python 2 compatible**, per 9d03ec5 — no f-strings. The
  server side uses them freely, as it already did.
- dB parsing handles the unicode minus and decimal commas that some locales render.
- No existing behaviour or response shape changes; this is purely additive.

## Testing

- Round-tripped `-60, -24, -12, -6, -4, -2, 0` dB: set, then read back. Error is 0.00 or
  0.01 dB throughout, i.e. at the display quantum.
- Edge cases: below the floor gives `-inf dB`, above the ceiling clamps to `+6.0 dB`,
  neither raises.
- Verified against a real 46-track set in Live 12 Suite.