### PR TITLE
Fix arm-state reads on group, return and main tracks

### DIFF
--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -597,7 +597,7 @@ class AbletonMCP(ControlSurface):
                 "is_midi_track": track.has_midi_input,
                 "mute": track.mute,
                 "solo": track.solo,
-                "arm": track.arm,
+                "arm": self._safe_arm(track),
                 "volume": track.mixer_device.volume.value,
                 "panning": track.mixer_device.panning.value,
                 "clip_slots": clip_slots,
@@ -608,6 +608,26 @@ class AbletonMCP(ControlSurface):
             self.log_message("Error getting track info: " + str(e))
             raise
     
+    def _safe_arm(self, track):
+        """Read track.arm, returning False for tracks that have no arm state.
+
+        Live raises RuntimeError("Master and Return Tracks have no 'Arm'
+        state!") for group tracks as well as return and main tracks. A
+        `getattr(track, "arm", False)` does not guard this: the attribute
+        exists, so getattr's default never applies -- reading it is what
+        throws, and the error is a RuntimeError rather than an AttributeError.
+
+        Check can_be_armed first so the common path does not rely on raising,
+        and keep a narrow catch for Live versions that do not expose that
+        property on every track type.
+        """
+        try:
+            if not getattr(track, "can_be_armed", False):
+                return False
+            return bool(track.arm)
+        except (AttributeError, RuntimeError):
+            return False
+
     def _create_midi_track(self, index):
         """Create a new MIDI track at the specified index"""
         try:
@@ -1673,7 +1693,7 @@ class AbletonMCP(ControlSurface):
                         elif kind == "solo_changed":
                             detail["solo"] = bool(t.solo)
                         elif kind == "arm_changed":
-                            detail["arm"] = bool(getattr(t, "arm", False))
+                            detail["arm"] = self._safe_arm(t)
                         elif kind == "devices_changed":
                             detail["device_count"] = len(t.devices)
                         elif kind == "volume_changed":
@@ -2233,7 +2253,7 @@ class AbletonMCP(ControlSurface):
                     "is_midi_track": bool(track.has_midi_input),
                     "mute": bool(track.mute),
                     "solo": bool(track.solo),
-                    "arm": bool(getattr(track, "arm", False)),
+                    "arm": self._safe_arm(track),
                     "volume": float(track.mixer_device.volume.value),
                     "panning": float(track.mixer_device.panning.value),
                     "sends": self._serialize_sends(track),

--- a/MCP_Server/bundled_ableton_remote_script/AbletonMCP_init.py
+++ b/MCP_Server/bundled_ableton_remote_script/AbletonMCP_init.py
@@ -597,7 +597,7 @@ class AbletonMCP(ControlSurface):
                 "is_midi_track": track.has_midi_input,
                 "mute": track.mute,
                 "solo": track.solo,
-                "arm": track.arm,
+                "arm": self._safe_arm(track),
                 "volume": track.mixer_device.volume.value,
                 "panning": track.mixer_device.panning.value,
                 "clip_slots": clip_slots,
@@ -608,6 +608,26 @@ class AbletonMCP(ControlSurface):
             self.log_message("Error getting track info: " + str(e))
             raise
     
+    def _safe_arm(self, track):
+        """Read track.arm, returning False for tracks that have no arm state.
+
+        Live raises RuntimeError("Master and Return Tracks have no 'Arm'
+        state!") for group tracks as well as return and main tracks. A
+        `getattr(track, "arm", False)` does not guard this: the attribute
+        exists, so getattr's default never applies -- reading it is what
+        throws, and the error is a RuntimeError rather than an AttributeError.
+
+        Check can_be_armed first so the common path does not rely on raising,
+        and keep a narrow catch for Live versions that do not expose that
+        property on every track type.
+        """
+        try:
+            if not getattr(track, "can_be_armed", False):
+                return False
+            return bool(track.arm)
+        except (AttributeError, RuntimeError):
+            return False
+
     def _create_midi_track(self, index):
         """Create a new MIDI track at the specified index"""
         try:
@@ -1673,7 +1693,7 @@ class AbletonMCP(ControlSurface):
                         elif kind == "solo_changed":
                             detail["solo"] = bool(t.solo)
                         elif kind == "arm_changed":
-                            detail["arm"] = bool(getattr(t, "arm", False))
+                            detail["arm"] = self._safe_arm(t)
                         elif kind == "devices_changed":
                             detail["device_count"] = len(t.devices)
                         elif kind == "volume_changed":
@@ -2233,7 +2253,7 @@ class AbletonMCP(ControlSurface):
                     "is_midi_track": bool(track.has_midi_input),
                     "mute": bool(track.mute),
                     "solo": bool(track.solo),
-                    "arm": bool(getattr(track, "arm", False)),
+                    "arm": self._safe_arm(track),
                     "volume": float(track.mixer_device.volume.value),
                     "panning": float(track.mixer_device.panning.value),
                     "sends": self._serialize_sends(track),


### PR DESCRIPTION
Fixes #126.

## Problem

Reading `.arm` on a track that cannot be armed raises rather than returning a value:

```
RuntimeError: Master and Return Tracks have no 'Arm' state!
```

Despite the message, Live applies this to **group tracks** as well as return and main tracks. Any Set containing a group track therefore:

- fails `get_track_info` on that track's index, and
- fails `get_session_snapshot` **entirely** — the snapshot serializes every track in one pass, so a single group anywhere in the Set takes down the whole call, including `cue_points`, which is reachable no other way.

As @mattbn73 notes in #126, this tends to surface to users as "locators don't work", which makes it hard to self-diagnose.

## Why the existing guards didn't work

Two of the three sites *looked* guarded:

```python
"arm": bool(getattr(track, "arm", False)),
```

`getattr`'s default only applies on `AttributeError`. The attribute exists — reading it is what throws, and it throws `RuntimeError`. So the default never applies and the exception propagates.

## Fix

Route all three reads through a `_safe_arm` helper, following the existing `_safe_song_property` / `_safe_add_listener` convention in this file:

```python
def _safe_arm(self, track):
    try:
        if not getattr(track, "can_be_armed", False):
            return False
        return bool(track.arm)
    except (AttributeError, RuntimeError):
        return False
```

Sites fixed:

| Site | Was |
|---|---|
| `_get_track_info` | bare `track.arm` |
| `_get_session_snapshot` track loop | ineffective `getattr` guard |
| `arm_changed` passive listener | ineffective `getattr` guard |

Two deliberate differences from the sketch in #126, both minor — happy to change either if you'd prefer the simpler form:

- **`can_be_armed` is checked first**, so the common path doesn't depend on raising. `get_session_snapshot` calls this once per track, and group tracks are common.
- **The catch is narrow** (`AttributeError`, `RuntimeError`) rather than bare `except Exception`, matching the "catches only narrow exceptions so genuine bugs still surface" note on `_safe_song_property`. `can_be_armed` handles the normal case, so the catch is only a fallback for Live versions that don't expose that property on every track type.

Group tracks now report `arm: false` instead of taking down the call.

## Applied to both copies

`AbletonMCP_Remote_Script/__init__.py` and `MCP_Server/bundled_ableton_remote_script/AbletonMCP_init.py` are byte-identical in this repo, so the fix is applied to both. Verified matching checksums after patching.

## Verification

Ableton Live 12 Suite 12.4.5, macOS 26.6.2, `SCRIPT_VERSION = "1.7.0"`.

Test Set: 25 tracks, **9 of them group tracks** (indices 2, 4, 10, 12, 14, 16, 18, 19, 22), including two levels of nesting.

**Before**

- `get_track_info` on each of the 9 group indices → `Main and Return Tracks have no 'Arm' state!` (9/9 failed)
- `get_session_snapshot` → failed outright, no data returned

**After**

- `get_track_info` on all 25 indices → 25/25 succeed; groups return `arm: false` with correct names and device lists
- `get_session_snapshot` → returns a complete 25-track payload (~58 KB), all 9 groups present

```
 2 'Instrumental' arm=False       14 'Synths'  arm=False
 4 'Drums'        arm=False       16 'FX'      arm=False
10 'Bass'         arm=False       18 'Vocals'  arm=False
12 'Samples'      arm=False       19 'Lead'    arm=False
                                  22 'Layer'   arm=False
```

`cue_points` is reachable again (empty in this Set, but the call no longer fails).

Existing test suite: 10/10 passing. Both script copies byte-compile clean.

One scope note: the first two sites are exercised directly by the calls above. The `arm_changed` listener fires only on a real arm toggle and is already wrapped in a broad `try/except` upstream of the read, so it was failing silently rather than visibly — that site is fixed for correctness and consistency, and verified by inspection rather than at runtime.

Reported against Live 11 in #126 and reproduced/fixed against Live 12 here, so this affects both. The change uses no syntax newer than Python 2.7, so it stays compatible with the Live 10 constraint.

## Credit

The diagnosis is @mattbn73's in #126 — including the `getattr`-doesn't-catch-`RuntimeError` root cause and the third site (the `arm_changed` listener), which I'd initially missed.
