### PR TITLE
feat: #127 loading and manipulating devices/effects on the master track

### DIFF
--- a/AbletonMCP_Remote_Script/__init__.py
+++ b/AbletonMCP_Remote_Script/__init__.py
@@ -21,7 +21,7 @@ HOST = "0.0.0.0"
 
 # Bumped whenever the TCP command surface changes; the MCP server compares
 # this to EXPECTED_REMOTE_SCRIPT_VERSION.
-SCRIPT_VERSION = "1.7.0"
+SCRIPT_VERSION = "1.8.0"
 PROTOCOL_VERSION = 1
 
 SCRIPT_CAPABILITIES = [
@@ -528,6 +528,16 @@ class AbletonMCP(ControlSurface):
     def _get_session_info(self):
         """Get information about the current session"""
         try:
+            master = self._song.master_track
+            master_devices = []
+            for device_index, device in enumerate(master.devices):
+                master_devices.append({
+                    "index": device_index,
+                    "name": device.name,
+                    "class_name": device.class_name,
+                    "type": self._get_device_type(device)
+                })
+
             result = {
                 "tempo": self._song.tempo,
                 "signature_numerator": self._song.signature_numerator,
@@ -535,9 +545,13 @@ class AbletonMCP(ControlSurface):
                 "track_count": len(self._song.tracks),
                 "return_track_count": len(self._song.return_tracks),
                 "master_track": {
-                    "name": "Master",
-                    "volume": self._song.master_track.mixer_device.volume.value,
-                    "panning": self._song.master_track.mixer_device.panning.value
+                    # Addressable as -1 by get_track_info / load_browser_item.
+                    "track_index": self.MASTER_TRACK_INDEX,
+                    "name": master.name,
+                    "volume": master.mixer_device.volume.value,
+                    "panning": master.mixer_device.panning.value,
+                    "device_count": len(master_devices),
+                    "devices": master_devices
                 },
                 # Read via _safe_song_property so an attribute missing on a
                 # given Live version falls back to its default.
@@ -554,16 +568,14 @@ class AbletonMCP(ControlSurface):
             raise
     
     def _get_track_info(self, track_index):
-        """Get information about a track"""
+        """Get information about a track (-1 = master track)"""
         try:
-            if track_index < 0 or track_index >= len(self._song.tracks):
-                raise IndexError("Track index out of range")
-            
-            track = self._song.tracks[track_index]
-            
-            # Get clip slots
+            track = self._resolve_track(track_index)
+            is_master = track is self._song.master_track
+
+            # The master track has no clip slots, arm, mute or solo.
             clip_slots = []
-            for slot_index, slot in enumerate(track.clip_slots):
+            for slot_index, slot in enumerate(getattr(track, "clip_slots", [])):
                 clip_info = None
                 if slot.has_clip:
                     clip = slot.clip
@@ -593,11 +605,12 @@ class AbletonMCP(ControlSurface):
             result = {
                 "index": track_index,
                 "name": track.name,
-                "is_audio_track": track.has_audio_input,
-                "is_midi_track": track.has_midi_input,
-                "mute": track.mute,
-                "solo": track.solo,
-                "arm": track.arm,
+                "is_master_track": is_master,
+                "is_audio_track": bool(getattr(track, "has_audio_input", is_master)),
+                "is_midi_track": bool(getattr(track, "has_midi_input", False)),
+                "mute": bool(getattr(track, "mute", False)),
+                "solo": bool(getattr(track, "solo", False)),
+                "arm": bool(getattr(track, "arm", False)),
                 "volume": track.mixer_device.volume.value,
                 "panning": track.mixer_device.panning.value,
                 "clip_slots": clip_slots,
@@ -648,17 +661,15 @@ class AbletonMCP(ControlSurface):
 
 
     def _set_track_name(self, track_index, name):
-        """Set the name of a track"""
+        """Set the name of a track. Accepts -1 for the master track."""
         try:
-            if track_index < 0 or track_index >= len(self._song.tracks):
-                raise IndexError("Track index out of range")
-            
-            # Set the name
-            track = self._song.tracks[track_index]
+            track = self._resolve_track(track_index)
             track.name = name
-            
+
             result = {
-                "name": track.name
+                "track_index": track_index,
+                "name": track.name,
+                "is_master_track": track is self._song.master_track,
             }
             return result
         except Exception as e:
@@ -1249,6 +1260,18 @@ class AbletonMCP(ControlSurface):
     
     
     
+    # Sentinel track index for the master track. 0 is a real, addressable
+    # regular track, so only a negative index is free to carry this meaning.
+    MASTER_TRACK_INDEX = -1
+
+    def _resolve_track(self, track_index):
+        """Resolve a track index, with -1 meaning the master track."""
+        if track_index == self.MASTER_TRACK_INDEX:
+            return self._song.master_track
+        if track_index < 0 or track_index >= len(self._song.tracks):
+            raise IndexError("Track index out of range")
+        return self._song.tracks[track_index]
+
     def _load_instrument_or_effect(self, track_index, uri):
         """Load an instrument or effect onto a track by its browser URI.
 
@@ -1262,13 +1285,10 @@ class AbletonMCP(ControlSurface):
         return self._load_browser_item(track_index, uri)
 
     def _load_browser_item(self, track_index, item_uri):
-        """Load a browser item onto a track by its URI"""
+        """Load a browser item onto a track by its URI (-1 = master track)"""
         try:
-            if track_index < 0 or track_index >= len(self._song.tracks):
-                raise IndexError("Track index out of range")
-            
-            track = self._song.tracks[track_index]
-            
+            track = self._resolve_track(track_index)
+
             # Access the application's browser instance instead of creating a new one
             app = self.application()
             
@@ -1288,6 +1308,7 @@ class AbletonMCP(ControlSurface):
                 "loaded": True,
                 "item_name": item.name,
                 "track_name": track.name,
+                "track_index": track_index,
                 "uri": item_uri
             }
             return result
@@ -1410,10 +1431,11 @@ class AbletonMCP(ControlSurface):
         return None, None
 
     def _inspect_rack(self, track_index, device_index=0):
-        """Inspect a rack's nested devices and blend parameters."""
-        if track_index < 0 or track_index >= len(self._song.tracks):
-            raise IndexError("Track index out of range")
-        track = self._song.tracks[track_index]
+        """Inspect a rack's nested devices and blend parameters.
+
+        Accepts -1 for the master track.
+        """
+        track = self._resolve_track(track_index)
         if device_index < 0 or device_index >= len(track.devices):
             raise IndexError("Device index out of range")
         rack = track.devices[device_index]
@@ -1448,10 +1470,11 @@ class AbletonMCP(ControlSurface):
         }
 
     def _map_rack_magnitude(self, track_index, device_index=0, macro_name="Magnitude"):
-        """Rename Macro 1 and map nested Dry/Wet (or Mix/Amount) params to it."""
-        if track_index < 0 or track_index >= len(self._song.tracks):
-            raise IndexError("Track index out of range")
-        track = self._song.tracks[track_index]
+        """Rename Macro 1 and map nested Dry/Wet (or Mix/Amount) params to it.
+
+        Accepts -1 for the master track.
+        """
+        track = self._resolve_track(track_index)
         if device_index < 0 or device_index >= len(track.devices):
             raise IndexError("Device index out of range")
         rack = track.devices[device_index]
@@ -2171,14 +2194,13 @@ class AbletonMCP(ControlSurface):
 
     def _get_device_parameters(self, track_index, device_index):
         try:
-            if track_index < 0 or track_index >= len(self._song.tracks):
-                raise IndexError("Track index out of range")
-            track = self._song.tracks[track_index]
+            track = self._resolve_track(track_index)
             if device_index < 0 or device_index >= len(track.devices):
                 raise IndexError("Device index out of range")
             device = track.devices[device_index]
             return {
                 "track_index": track_index,
+                "is_master_track": track is self._song.master_track,
                 "device": self._serialize_device(device, device_index, include_params=True),
             }
         except Exception as e:
@@ -2263,9 +2285,7 @@ class AbletonMCP(ControlSurface):
 
     def _set_device_parameter(self, track_index, device_index, parameter_index, value):
         try:
-            if track_index < 0 or track_index >= len(self._song.tracks):
-                raise IndexError("Track index out of range")
-            track = self._song.tracks[track_index]
+            track = self._resolve_track(track_index)
             if device_index < 0 or device_index >= len(track.devices):
                 raise IndexError("Device index out of range")
             device = track.devices[device_index]
@@ -2276,6 +2296,7 @@ class AbletonMCP(ControlSurface):
             param.value = float(value)
             return {
                 "track_index": track_index,
+                "is_master_track": track is self._song.master_track,
                 "device_index": device_index,
                 "parameter_index": parameter_index,
                 "name": param.name,

--- a/MCP_Server/bundled_ableton_remote_script/AbletonMCP_init.py
+++ b/MCP_Server/bundled_ableton_remote_script/AbletonMCP_init.py
@@ -21,7 +21,7 @@ HOST = "0.0.0.0"
 
 # Bumped whenever the TCP command surface changes; the MCP server compares
 # this to EXPECTED_REMOTE_SCRIPT_VERSION.
-SCRIPT_VERSION = "1.7.0"
+SCRIPT_VERSION = "1.8.0"
 PROTOCOL_VERSION = 1
 
 SCRIPT_CAPABILITIES = [
@@ -528,6 +528,16 @@ class AbletonMCP(ControlSurface):
     def _get_session_info(self):
         """Get information about the current session"""
         try:
+            master = self._song.master_track
+            master_devices = []
+            for device_index, device in enumerate(master.devices):
+                master_devices.append({
+                    "index": device_index,
+                    "name": device.name,
+                    "class_name": device.class_name,
+                    "type": self._get_device_type(device)
+                })
+
             result = {
                 "tempo": self._song.tempo,
                 "signature_numerator": self._song.signature_numerator,
@@ -535,9 +545,13 @@ class AbletonMCP(ControlSurface):
                 "track_count": len(self._song.tracks),
                 "return_track_count": len(self._song.return_tracks),
                 "master_track": {
-                    "name": "Master",
-                    "volume": self._song.master_track.mixer_device.volume.value,
-                    "panning": self._song.master_track.mixer_device.panning.value
+                    # Addressable as -1 by get_track_info / load_browser_item.
+                    "track_index": self.MASTER_TRACK_INDEX,
+                    "name": master.name,
+                    "volume": master.mixer_device.volume.value,
+                    "panning": master.mixer_device.panning.value,
+                    "device_count": len(master_devices),
+                    "devices": master_devices
                 },
                 # Read via _safe_song_property so an attribute missing on a
                 # given Live version falls back to its default.
@@ -554,16 +568,14 @@ class AbletonMCP(ControlSurface):
             raise
     
     def _get_track_info(self, track_index):
-        """Get information about a track"""
+        """Get information about a track (-1 = master track)"""
         try:
-            if track_index < 0 or track_index >= len(self._song.tracks):
-                raise IndexError("Track index out of range")
-            
-            track = self._song.tracks[track_index]
-            
-            # Get clip slots
+            track = self._resolve_track(track_index)
+            is_master = track is self._song.master_track
+
+            # The master track has no clip slots, arm, mute or solo.
             clip_slots = []
-            for slot_index, slot in enumerate(track.clip_slots):
+            for slot_index, slot in enumerate(getattr(track, "clip_slots", [])):
                 clip_info = None
                 if slot.has_clip:
                     clip = slot.clip
@@ -593,11 +605,12 @@ class AbletonMCP(ControlSurface):
             result = {
                 "index": track_index,
                 "name": track.name,
-                "is_audio_track": track.has_audio_input,
-                "is_midi_track": track.has_midi_input,
-                "mute": track.mute,
-                "solo": track.solo,
-                "arm": track.arm,
+                "is_master_track": is_master,
+                "is_audio_track": bool(getattr(track, "has_audio_input", is_master)),
+                "is_midi_track": bool(getattr(track, "has_midi_input", False)),
+                "mute": bool(getattr(track, "mute", False)),
+                "solo": bool(getattr(track, "solo", False)),
+                "arm": bool(getattr(track, "arm", False)),
                 "volume": track.mixer_device.volume.value,
                 "panning": track.mixer_device.panning.value,
                 "clip_slots": clip_slots,
@@ -648,17 +661,15 @@ class AbletonMCP(ControlSurface):
 
 
     def _set_track_name(self, track_index, name):
-        """Set the name of a track"""
+        """Set the name of a track. Accepts -1 for the master track."""
         try:
-            if track_index < 0 or track_index >= len(self._song.tracks):
-                raise IndexError("Track index out of range")
-            
-            # Set the name
-            track = self._song.tracks[track_index]
+            track = self._resolve_track(track_index)
             track.name = name
-            
+
             result = {
-                "name": track.name
+                "track_index": track_index,
+                "name": track.name,
+                "is_master_track": track is self._song.master_track,
             }
             return result
         except Exception as e:
@@ -1249,6 +1260,18 @@ class AbletonMCP(ControlSurface):
     
     
     
+    # Sentinel track index for the master track. 0 is a real, addressable
+    # regular track, so only a negative index is free to carry this meaning.
+    MASTER_TRACK_INDEX = -1
+
+    def _resolve_track(self, track_index):
+        """Resolve a track index, with -1 meaning the master track."""
+        if track_index == self.MASTER_TRACK_INDEX:
+            return self._song.master_track
+        if track_index < 0 or track_index >= len(self._song.tracks):
+            raise IndexError("Track index out of range")
+        return self._song.tracks[track_index]
+
     def _load_instrument_or_effect(self, track_index, uri):
         """Load an instrument or effect onto a track by its browser URI.
 
@@ -1262,13 +1285,10 @@ class AbletonMCP(ControlSurface):
         return self._load_browser_item(track_index, uri)
 
     def _load_browser_item(self, track_index, item_uri):
-        """Load a browser item onto a track by its URI"""
+        """Load a browser item onto a track by its URI (-1 = master track)"""
         try:
-            if track_index < 0 or track_index >= len(self._song.tracks):
-                raise IndexError("Track index out of range")
-            
-            track = self._song.tracks[track_index]
-            
+            track = self._resolve_track(track_index)
+
             # Access the application's browser instance instead of creating a new one
             app = self.application()
             
@@ -1288,6 +1308,7 @@ class AbletonMCP(ControlSurface):
                 "loaded": True,
                 "item_name": item.name,
                 "track_name": track.name,
+                "track_index": track_index,
                 "uri": item_uri
             }
             return result
@@ -1410,10 +1431,11 @@ class AbletonMCP(ControlSurface):
         return None, None
 
     def _inspect_rack(self, track_index, device_index=0):
-        """Inspect a rack's nested devices and blend parameters."""
-        if track_index < 0 or track_index >= len(self._song.tracks):
-            raise IndexError("Track index out of range")
-        track = self._song.tracks[track_index]
+        """Inspect a rack's nested devices and blend parameters.
+
+        Accepts -1 for the master track.
+        """
+        track = self._resolve_track(track_index)
         if device_index < 0 or device_index >= len(track.devices):
             raise IndexError("Device index out of range")
         rack = track.devices[device_index]
@@ -1448,10 +1470,11 @@ class AbletonMCP(ControlSurface):
         }
 
     def _map_rack_magnitude(self, track_index, device_index=0, macro_name="Magnitude"):
-        """Rename Macro 1 and map nested Dry/Wet (or Mix/Amount) params to it."""
-        if track_index < 0 or track_index >= len(self._song.tracks):
-            raise IndexError("Track index out of range")
-        track = self._song.tracks[track_index]
+        """Rename Macro 1 and map nested Dry/Wet (or Mix/Amount) params to it.
+
+        Accepts -1 for the master track.
+        """
+        track = self._resolve_track(track_index)
         if device_index < 0 or device_index >= len(track.devices):
             raise IndexError("Device index out of range")
         rack = track.devices[device_index]
@@ -2171,14 +2194,13 @@ class AbletonMCP(ControlSurface):
 
     def _get_device_parameters(self, track_index, device_index):
         try:
-            if track_index < 0 or track_index >= len(self._song.tracks):
-                raise IndexError("Track index out of range")
-            track = self._song.tracks[track_index]
+            track = self._resolve_track(track_index)
             if device_index < 0 or device_index >= len(track.devices):
                 raise IndexError("Device index out of range")
             device = track.devices[device_index]
             return {
                 "track_index": track_index,
+                "is_master_track": track is self._song.master_track,
                 "device": self._serialize_device(device, device_index, include_params=True),
             }
         except Exception as e:
@@ -2263,9 +2285,7 @@ class AbletonMCP(ControlSurface):
 
     def _set_device_parameter(self, track_index, device_index, parameter_index, value):
         try:
-            if track_index < 0 or track_index >= len(self._song.tracks):
-                raise IndexError("Track index out of range")
-            track = self._song.tracks[track_index]
+            track = self._resolve_track(track_index)
             if device_index < 0 or device_index >= len(track.devices):
                 raise IndexError("Device index out of range")
             device = track.devices[device_index]
@@ -2276,6 +2296,7 @@ class AbletonMCP(ControlSurface):
             param.value = float(value)
             return {
                 "track_index": track_index,
+                "is_master_track": track is self._song.master_track,
                 "device_index": device_index,
                 "parameter_index": parameter_index,
                 "name": param.name,

--- a/MCP_Server/remote_script_install.py
+++ b/MCP_Server/remote_script_install.py
@@ -20,7 +20,7 @@ from pathlib import Path
 logger = logging.getLogger("ableton-mcp-remote-script")
 
 # Must match SCRIPT_VERSION in AbletonMCP_Remote_Script/__init__.py
-EXPECTED_REMOTE_SCRIPT_VERSION = "1.7.0"
+EXPECTED_REMOTE_SCRIPT_VERSION = "1.8.0"
 REMOTE_SCRIPT_FOLDER_NAME = "AbletonMCP"
 
 

--- a/MCP_Server/server.py
+++ b/MCP_Server/server.py
@@ -455,7 +455,8 @@ def get_track_info(ctx: Context, track_index: int, user_prompt: str = "") -> str
     Get detailed information about a specific track in Ableton.
 
     Parameters:
-    - track_index: The index of the track to get information about
+    - track_index: The index of the track to get information about. Pass -1 for
+      the master track, which reports no clip slots and no arm/mute/solo.
     - user_prompt: The original user prompt that led to this tool call (for telemetry)
     """
     try:
@@ -516,7 +517,7 @@ def get_device_parameters(
     Read all parameters for a device on a track (name, value, min, max).
 
     Parameters:
-    - track_index: Track that owns the device
+    - track_index: Track that owns the device. Pass -1 for the master track.
     - device_index: Index into the track's device chain
     - user_prompt: The original user prompt that led to this tool call (for telemetry)
     """
@@ -549,7 +550,7 @@ def set_device_parameter(
     Use get_device_parameters first to discover parameter indices and ranges.
 
     Parameters:
-    - track_index: Track that owns the device
+    - track_index: Track that owns the device. Pass -1 for the master track.
     - device_index: Index into the track's device chain
     - parameter_index: Index into device.parameters
     - value: New parameter value (Live parameter units)
@@ -667,7 +668,7 @@ def set_track_name(ctx: Context, track_index: int, name: str, user_prompt: str =
     Set the name of a track.
 
     Parameters:
-    - track_index: The index of the track to rename
+    - track_index: The index of the track to rename. Pass -1 for the master track.
     - name: The new name for the track
     - user_prompt: The original user prompt that led to this tool call (for telemetry)
     """
@@ -887,7 +888,8 @@ def load_instrument_or_effect(ctx: Context, track_index: int, uri: str, user_pro
     Load an instrument or effect onto a track using its URI.
 
     Parameters:
-    - track_index: The index of the track to load the instrument on
+    - track_index: The index of the track to load the instrument on. Pass -1 to
+      target the master track, which accepts audio effects only.
     - uri: The URI of the instrument or effect to load (e.g., 'query:Synths#Instrument%20Rack:Bass:FileId_5116')
     - user_prompt: The original user prompt that led to this tool call (for telemetry)
     """
@@ -897,15 +899,17 @@ def load_instrument_or_effect(ctx: Context, track_index: int, uri: str, user_pro
             "track_index": track_index,
             "item_uri": uri
         })
-        
+
+        target = "the master track" if track_index == -1 else f"track {track_index}"
+
         # Check if the instrument was loaded successfully
         if result.get("loaded", False):
             new_devices = result.get("new_devices", [])
             if new_devices:
-                return f"Loaded instrument with URI '{uri}' on track {track_index}. New devices: {', '.join(new_devices)}"
+                return f"Loaded instrument with URI '{uri}' on {target}. New devices: {', '.join(new_devices)}"
             else:
                 devices = result.get("devices_after", [])
-                return f"Loaded instrument with URI '{uri}' on track {track_index}. Devices on track: {', '.join(devices)}"
+                return f"Loaded instrument with URI '{uri}' on {target}. Devices on track: {', '.join(devices)}"
         else:
             return f"Failed to load instrument with URI '{uri}'"
     except Exception as e:

--- a/tests/test_clip_notes.py
+++ b/tests/test_clip_notes.py
@@ -132,6 +132,34 @@ def test_add_notes_forwards_track_clip_and_notes(fake_conn):
                           {"track_index": 3, "clip_index": 7, "notes": one})]
 
 
+@pytest.mark.parametrize(
+    ("tool_name", "args", "expected_command"),
+    [
+        ("get_track_info", {"track_index": -1}, {"track_index": -1}),
+        ("get_device_parameters", {"track_index": -1, "device_index": 0}, {"track_index": -1, "device_index": 0}),
+        ("set_device_parameter", {"track_index": -1, "device_index": 0, "parameter_index": 3, "value": 0.25}, {"track_index": -1, "device_index": 0, "parameter_index": 3, "value": 0.25}),
+        ("set_track_name", {"track_index": -1, "name": "Master"}, {"track_index": -1, "name": "Master"}),
+    ],
+)
+def test_master_track_tools_accept_minus_one_index(fake_conn, tool_name, args, expected_command):
+    """The master-track sentinel should be transmitted unchanged for device and
+    naming operations that are valid on the master bus."""
+    conn = fake_conn(response={"ok": True})
+
+    if tool_name == "get_track_info":
+        server.get_track_info(None, **args)
+    elif tool_name == "get_device_parameters":
+        server.get_device_parameters(None, **args)
+    elif tool_name == "set_device_parameter":
+        server.set_device_parameter(None, **args)
+    elif tool_name == "set_track_name":
+        server.set_track_name(None, **args)
+    else:
+        raise AssertionError(f"Unhandled tool_name: {tool_name}")
+
+    assert conn.sent == [(tool_name, expected_command)]
+
+
 # --------------------------------------------------------------------------
 # clear_notes_from_clip  +  the true replace loop
 # --------------------------------------------------------------------------


### PR DESCRIPTION
- treats the master track as track_index -1
- documents that special index both in the get_session_info of the master_track as in all method docstrings
- introduces a resolve_track helper which does the de-indexing
- use the resolve_track in all relevant effect/non-clip device related methods

Closes #127 